### PR TITLE
Fix GetExternalJointPositions indexing wrong list

### DIFF
--- a/RobotComponents.ABB.Controllers/Controller.cs
+++ b/RobotComponents.ABB.Controllers/Controller.cs
@@ -558,7 +558,7 @@ namespace RobotComponents.ABB.Controllers
 
             for (int i = 0; i < _externalAxes.Count; i++)
             {
-                RapidDomainNS.JointTarget jointTarget = _mechanicalUnits[i].GetPosition();
+                RapidDomainNS.JointTarget jointTarget = _externalAxes[i].GetPosition();
 
                 for (int j = 0; j < _externalAxes[i].NumberOfAxes; j++)
                 {


### PR DESCRIPTION
The loop iterated over _externalAxes but read positions from _mechanicalUnits[i], which contains robots first then external axes. This returned robot positions instead of external axis positions when robots were present.