### PR TITLE
Fix NaN comparison in RobotKinematicParameters.IsValid

### DIFF
--- a/RobotComponents.ABB/Definitions/RobotKinematicParameters.cs
+++ b/RobotComponents.ABB/Definitions/RobotKinematicParameters.cs
@@ -219,14 +219,14 @@ namespace RobotComponents.ABB.Definitions
         {
             get 
             {
-                if (_a1 == double.NaN) { return false; }
-                if (_a2 == double.NaN) { return false; }
-                if (_a3 == double.NaN) { return false; }
-                if (_b == double.NaN) { return false; }
-                if (_c1 == double.NaN) { return false; }
-                if (_c2 == double.NaN) { return false; }
-                if (_c3 == double.NaN) { return false; }
-                if (_c4 == double.NaN) { return false; }
+                if (double.IsNaN(_a1)) { return false; }
+                if (double.IsNaN(_a2)) { return false; }
+                if (double.IsNaN(_a3)) { return false; }
+                if (double.IsNaN(_b)) { return false; }
+                if (double.IsNaN(_c1)) { return false; }
+                if (double.IsNaN(_c2)) { return false; }
+                if (double.IsNaN(_c3)) { return false; }
+                if (double.IsNaN(_c4)) { return false; }
                 return true; 
             }
         }


### PR DESCRIPTION
## Summary
- `IsValid` always returned `true` because `_a1 == double.NaN` is always `false` per IEEE 754
- Replaced all 8 checks with `double.IsNaN()` so uninitialized instances are correctly detected as invalid

## Details
The parameterless constructor sets all kinematic fields to `double.NaN`. The `IsValid` property was supposed to catch this, but `NaN == NaN` is always `false` in floating-point math. Any code path relying on `IsValid` to reject bad parameters silently accepted them.

## File changed
- `RobotComponents.ABB/Definitions/RobotKinematicParameters.cs` (lines 222-229)