### PR TITLE
Fix shoulder singularity detection no-op in OPWKinematics

### DIFF
--- a/RobotComponents/Generic/Kinematics/OPWKinematics.cs
+++ b/RobotComponents/Generic/Kinematics/OPWKinematics.cs
@@ -334,13 +334,11 @@ namespace RobotComponents.Generic.Kinematics
             _elbowSingularities[7] = singularity2;
 
             // Shoulder singularity
-            if ((Math.Abs(cx0) < 1e-3) & (Math.Abs(cy0) < 1e-3))
+            bool shoulderSingularity = (Math.Abs(cx0) < 1e-3) && (Math.Abs(cy0) < 1e-3);
+
+            for (int i = 0; i < 8; i++)
             {
-                _shoulderSingularities.Select(item => item = true);
-            }
-            else
-            {
-                _shoulderSingularities.Select(item => item = false);
+                _shoulderSingularities[i] = shoulderSingularity;
             }
 
             // Corrections


### PR DESCRIPTION
## Summary
- Shoulder singularity detection never flagged any solutions because the LINQ `.Select()` result was discarded
- Replaced with a `for` loop that actually writes to the `_shoulderSingularities` array
- Also fixed bitwise `&` to logical `&&` in the condition

## Details
When `cx0` and `cy0` are both near zero (shoulder singularity), the code attempted:
```csharp
_shoulderSingularities.Select(item => item = true);
```
LINQ `.Select()` is lazy — it returns an `IEnumerable` that was never iterated, so the array was never modified. Additionally, `bool` is a value type so the lambda assignment wouldn't modify the original array element even if executed. The singularity array stayed all-`false` forever.

## File changed
- `RobotComponents/Generic/Kinematics/OPWKinematics.cs` (lines 337-344)