### PR TITLE
Fix WaitGO and WaitGI generating WaitDI RAPID instruction

### DIFF
--- a/RobotComponents.ABB/Actions/Instructions/WaitGI.cs
+++ b/RobotComponents.ABB/Actions/Instructions/WaitGI.cs
@@ -20,10 +20,10 @@ using RobotComponents.ABB.Definitions;
 namespace RobotComponents.ABB.Actions.Instructions
 {
     /// <summary>
-    /// Represents a Wait for Digital Input instruction.
+    /// Represents a Wait for Group Input instruction.
     /// </summary>
     /// <remarks>
-    /// This action is used to wait until a digital input is set.
+    /// This action is used to wait until a group input is set.
     /// </remarks>
     [Serializable()]
     public class WaitGI : IAction, IInstruction, ISerializable
@@ -175,7 +175,7 @@ namespace RobotComponents.ABB.Actions.Instructions
         {
             if (_maxTime > 0)
             {
-                string result = $"WaitDI {_name}, {_value} ";
+                string result = $"WaitGI {_name}, {_value} ";
                 result += $"\\MaxTime:={_maxTime:0.###}";
                 //result += $"{(_timeFlag ? $"\\TimeFlag:=TRUE" : $"\\TimeFlag:=FALSE")}";
                 result += ";";
@@ -184,7 +184,7 @@ namespace RobotComponents.ABB.Actions.Instructions
             }
             else
             {
-                return $"WaitDI {_name}, {_value};";
+                return $"WaitGI {_name}, {_value};";
             }
         }
 

--- a/RobotComponents.ABB/Actions/Instructions/WaitGO.cs
+++ b/RobotComponents.ABB/Actions/Instructions/WaitGO.cs
@@ -20,10 +20,10 @@ using RobotComponents.ABB.Definitions;
 namespace RobotComponents.ABB.Actions.Instructions
 {
     /// <summary>
-    /// Represents a Wait for Digital Output instruction.
+    /// Represents a Wait for Group Output instruction.
     /// </summary>
     /// <remarks>
-    /// This action is used to wait until a digital output is set.
+    /// This action is used to wait until a group output is set.
     /// </remarks>
     [Serializable()]
     public class WaitGO : IAction, IInstruction, ISerializable
@@ -175,7 +175,7 @@ namespace RobotComponents.ABB.Actions.Instructions
         {
             if (_maxTime > 0)
             {
-                string result = $"WaitDI {_name}, {_value} ";
+                string result = $"WaitGO {_name}, {_value} ";
                 result += $"\\MaxTime:={_maxTime:0.###}";
                 //result += $"{(_timeFlag ? $"\\TimeFlag:=TRUE" : $"\\TimeFlag:=FALSE")}";
                 result += ";";
@@ -184,7 +184,7 @@ namespace RobotComponents.ABB.Actions.Instructions
             }
             else
             {
-                return $"WaitDI {_name}, {_value};";
+                return $"WaitGO {_name}, {_value};";
             }
         }
 


### PR DESCRIPTION
## Summary
- `WaitGO.ToRAPIDInstruction()` generated `"WaitDI ..."` instead of `"WaitGO ..."`
- `WaitGI.ToRAPIDInstruction()` generated `"WaitDI ..."` instead of `"WaitGI ..."`
- Both classes were copy-pasted from `WaitDI` with the instruction name left unchanged
- Also fixed XML doc comments that still referenced "Digital Input/Output" instead of "Group Input/Output"

## Details
Any robot program using `WaitGO` or `WaitGI` would generate RAPID code that waits on a digital input signal instead of a group output/input signal — completely wrong behavior on the ABB controller.

## Files changed
- `RobotComponents.ABB/Actions/Instructions/WaitGO.cs` (lines 22-27, 178, 187)
- `RobotComponents.ABB/Actions/Instructions/WaitGI.cs` (lines 22-27, 178, 187)