### PR TITLE
Fix missing early returns in Controller and remove redundant credential fields

### DIFF
--- a/RobotComponents.ABB.Controllers/Controller.cs
+++ b/RobotComponents.ABB.Controllers/Controller.cs
@@ -52,8 +52,6 @@ namespace RobotComponents.ABB.Controllers
 
         private ControllersNS.Controller _controller;
         private ControllersNS.UserInfo _userInfo = ControllersNS.UserInfo.DefaultUser;
-        private string _userName = ControllersNS.UserInfo.DefaultUser.Name;
-        private string _password = ControllersNS.UserInfo.DefaultUser.Password;
         private readonly List<string> _logger = new List<string>();
 
         private List<RapidDomainNS.Task> _tasks = new List<RapidDomainNS.Task>();
@@ -188,6 +186,7 @@ namespace RobotComponents.ABB.Controllers
             {
                 _isInitialized = false;
                 Log("Could not initialize the controller instance: There is no ABB controller defined.");
+                return;
             }
 
             #region mechanical units
@@ -318,13 +317,13 @@ namespace RobotComponents.ABB.Controllers
             try
             {
                 _controller.Logon(_userInfo);
-                Log($"Logged in with username {_userName}.");
+                Log($"Logged in with username {_userInfo.Name}.");
                 return true;
             }
 
             catch (Exception e)
             {
-                Log($"Could not logon with username {_userName}: {e.Message}.");
+                Log($"Could not logon with username {_userInfo.Name}: {e.Message}.");
                 return false;
             }
         }
@@ -824,15 +823,13 @@ namespace RobotComponents.ABB.Controllers
             if (_isEmpty == true)
             {
                 Log("Could not set the user info: The controller is empty.");
+                return;
             }
 
             try
             {
-                _userName = name;
-                _password = password;
-
-                _userInfo = new ControllersNS.UserInfo(_userName, _password);
-                Log($"User info set to {_userName}.");
+                _userInfo = new ControllersNS.UserInfo(name, password);
+                Log($"User info set to {_userInfo.Name}.");
             }
             catch (Exception e)
             {
@@ -848,11 +845,10 @@ namespace RobotComponents.ABB.Controllers
             if (_isEmpty == true)
             {
                 Log("Could not set the default user: The controller is empty.");
+                return;
             }
 
-            _userName = ControllersNS.UserInfo.DefaultUser.Name;
-            _password = ControllersNS.UserInfo.DefaultUser.Password;
-
+            _userInfo = ControllersNS.UserInfo.DefaultUser;
             Log("User info set to DefaultUser.");
         }
 
@@ -2104,7 +2100,7 @@ namespace RobotComponents.ABB.Controllers
         /// </summary>
         public string UserName
         {
-            get { return _userName; }
+            get { return _userInfo.Name; }
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- `Initiliaze()`, `SetUserInfo()`, and `SetDefaultUser()` all logged an error when `_isEmpty == true` but continued executing, causing `NullReferenceException` on the null `_controller`
- `SetDefaultUser()` updated `_userName`/`_password` but never updated `_userInfo`, so `Logon()` still used stale credentials
- Removed redundant `_userName` and `_password` fields — `_userInfo` is now the single source of truth

## Details
The `_userName` and `_password` fields were copies of data already stored in `_userInfo`. They had to be kept in sync manually, and `SetDefaultUser()` proved they weren't — it updated the strings but forgot `_userInfo`, so calling `Logon()` after `SetDefaultUser()` would authenticate with the previous user.

Now `_userInfo` is the only credential store. `SetUserInfo()` creates a new `UserInfo` object directly, `SetDefaultUser()` assigns `UserInfo.DefaultUser`, and all log messages and the `UserName` getter read from `_userInfo.Name`.

## Changes
- Added `return;` after empty checks in `Initiliaze()`, `SetUserInfo()`, `SetDefaultUser()`
- Removed `_userName` and `_password` fields (lines 55-56)
- `SetUserInfo()`: builds `_userInfo` directly from parameters
- `SetDefaultUser()`: assigns `_userInfo = ControllersNS.UserInfo.DefaultUser`
- `UserName` getter: returns `_userInfo.Name`
- Log messages: use `_userInfo.Name`

## File changed
- `RobotComponents.ABB.Controllers/Controller.cs`