### PR TITLE
Fix Signal.SetValue missing return on empty check

### DIFF
--- a/RobotComponents.ABB.Controllers/Signal.cs
+++ b/RobotComponents.ABB.Controllers/Signal.cs
@@ -149,6 +149,7 @@ namespace RobotComponents.ABB.Controllers
             if (_isEmpty == true)
             {
                 msg = $"Could not set the value of the signal. No signal defined.";
+                return false;
             }
 
             if (_limits.IncludesParameter(value, false) == false)


### PR DESCRIPTION
## Summary
- `SetValue()` set an error message when `_isEmpty == true` but did not return
- Execution fell through to `_limits.IncludesParameter()` and `_signal.Name`, both null for empty signals, causing `NullReferenceException`
- Added `return false;` after the error message

## File changed
- `RobotComponents.ABB.Controllers/Signal.cs` (line 151)