### PR TITLE
Fix special character validation calling wrong method

### DIFF
--- a/RobotComponents.ABB.Gh/Components/Code Generation/Instructions/LoadModuleComponent.cs
+++ b/RobotComponents.ABB.Gh/Components/Code Generation/Instructions/LoadModuleComponent.cs
@@ -88,9 +88,9 @@ namespace RobotComponents.ABB.Gh.Components.CodeGeneration
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "Module name starts with a number which is not allowed in RAPID code.");
             }
-            if (HelperMethods.StringStartsWithNumber(name))
+            if (HelperMethods.StringHasSpecialCharacters(name))
             {
-                AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "Module name constains special characters which is not allowed in RAPID code.");
+                AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "Module name contains special characters which is not allowed in RAPID code.");
             }
 
             string remoteAdditionalDirectory = "HOME:/Robot Components/Additional Modules/";

--- a/RobotComponents.ABB.Gh/Components/Code Generation/Instructions/PulseDigitalOutputComponent.cs
+++ b/RobotComponents.ABB.Gh/Components/Code Generation/Instructions/PulseDigitalOutputComponent.cs
@@ -81,9 +81,9 @@ namespace RobotComponents.ABB.Gh.Components.CodeGeneration
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "Digital output name starts with a number which is not allowed in RAPID code.");
             }
-            if (HelperMethods.StringStartsWithNumber(name))
+            if (HelperMethods.StringHasSpecialCharacters(name))
             {
-                AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "Digital output name constains special characters which is not allowed in RAPID code.");
+                AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "Digital output name contains special characters which is not allowed in RAPID code.");
             }
 
             // Create the action

--- a/RobotComponents.ABB.Gh/Components/Code Generation/Instructions/SetAnalogOutputComponent.cs
+++ b/RobotComponents.ABB.Gh/Components/Code Generation/Instructions/SetAnalogOutputComponent.cs
@@ -78,9 +78,9 @@ namespace RobotComponents.ABB.Gh.Components.CodeGeneration
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "Analog output name starts with a number which is not allowed in RAPID code.");
             }
-            if (HelperMethods.StringStartsWithNumber(name))
+            if (HelperMethods.StringHasSpecialCharacters(name))
             {
-                AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "Analog output name constains special characters which is not allowed in RAPID code.");
+                AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "Analog output name contains special characters which is not allowed in RAPID code.");
             }
 
             // Create the action

--- a/RobotComponents.ABB.Gh/Components/Code Generation/Instructions/SetDigitalOutputComponent.cs
+++ b/RobotComponents.ABB.Gh/Components/Code Generation/Instructions/SetDigitalOutputComponent.cs
@@ -81,9 +81,9 @@ namespace RobotComponents.ABB.Gh.Components.CodeGeneration
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "Digital output name starts with a number which is not allowed in RAPID code.");
             }
-            if (HelperMethods.StringStartsWithNumber(name))
+            if (HelperMethods.StringHasSpecialCharacters(name))
             {
-                AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "Digital output name constains special characters which is not allowed in RAPID code.");
+                AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "Digital output name contains special characters which is not allowed in RAPID code.");
             }
 
             // Create the action

--- a/RobotComponents.ABB.Gh/Components/Code Generation/Instructions/SetGroupOutputComponent.cs
+++ b/RobotComponents.ABB.Gh/Components/Code Generation/Instructions/SetGroupOutputComponent.cs
@@ -170,9 +170,9 @@ namespace RobotComponents.ABB.Gh.Components.CodeGeneration
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "Group output name starts with a number which is not allowed in RAPID code.");
             }
-            if (HelperMethods.StringStartsWithNumber(name))
+            if (HelperMethods.StringHasSpecialCharacters(name))
             {
-                AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "Group output name constains special characters which is not allowed in RAPID code.");
+                AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "Group output name contains special characters which is not allowed in RAPID code.");
             }
 
             // Gets bitmask values from variable input parameters

--- a/RobotComponents.ABB.Gh/Components/Code Generation/Instructions/WaitAIComponent.cs
+++ b/RobotComponents.ABB.Gh/Components/Code Generation/Instructions/WaitAIComponent.cs
@@ -108,9 +108,9 @@ namespace RobotComponents.ABB.Gh.Components.CodeGeneration
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "Analog input name starts with a number which is not allowed in RAPID code.");
             }
-            if (HelperMethods.StringStartsWithNumber(name))
+            if (HelperMethods.StringHasSpecialCharacters(name))
             {
-                AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "Analog input name constains special characters which is not allowed in RAPID code.");
+                AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "Analog input name contains special characters which is not allowed in RAPID code.");
             }
 
             // Create the action

--- a/RobotComponents.ABB.Gh/Components/Code Generation/Instructions/WaitAOComponent.cs
+++ b/RobotComponents.ABB.Gh/Components/Code Generation/Instructions/WaitAOComponent.cs
@@ -109,9 +109,9 @@ namespace RobotComponents.ABB.Gh.Components.CodeGeneration
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "Analog output name starts with a number which is not allowed in RAPID code.");
             }
-            if (HelperMethods.StringStartsWithNumber(name))
+            if (HelperMethods.StringHasSpecialCharacters(name))
             {
-                AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "Analog output name constains special characters which is not allowed in RAPID code.");
+                AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "Analog output name contains special characters which is not allowed in RAPID code.");
             }
 
             // Create the action

--- a/RobotComponents.ABB.Gh/Components/Code Generation/Instructions/WaitDIComponent.cs
+++ b/RobotComponents.ABB.Gh/Components/Code Generation/Instructions/WaitDIComponent.cs
@@ -80,9 +80,9 @@ namespace RobotComponents.ABB.Gh.Components.CodeGeneration
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "Digital input name starts with a number which is not allowed in RAPID code.");
             }
-            if (HelperMethods.StringStartsWithNumber(name))
+            if (HelperMethods.StringHasSpecialCharacters(name))
             {
-                AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "Digital input name constains special characters which is not allowed in RAPID code.");
+                AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "Digital input name contains special characters which is not allowed in RAPID code.");
             }
 
             // Create the action

--- a/RobotComponents.ABB.Gh/Components/Code Generation/Instructions/WaitDOComponent.cs
+++ b/RobotComponents.ABB.Gh/Components/Code Generation/Instructions/WaitDOComponent.cs
@@ -78,9 +78,9 @@ namespace RobotComponents.ABB.Gh.Components.CodeGeneration
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "Digital output name starts with a number which is not allowed in RAPID code.");
             }
-            if (HelperMethods.StringStartsWithNumber(name))
+            if (HelperMethods.StringHasSpecialCharacters(name))
             {
-                AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "Digital output name constains special characters which is not allowed in RAPID code.");
+                AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "Digital output name contains special characters which is not allowed in RAPID code.");
             }
 
             // Create the action

--- a/RobotComponents.ABB.Gh/Components/Code Generation/Instructions/WaitGIComponent.cs
+++ b/RobotComponents.ABB.Gh/Components/Code Generation/Instructions/WaitGIComponent.cs
@@ -78,9 +78,9 @@ namespace RobotComponents.ABB.Gh.Components.CodeGeneration
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "Group input name starts with a number which is not allowed in RAPID code.");
             }
-            if (HelperMethods.StringStartsWithNumber(name))
+            if (HelperMethods.StringHasSpecialCharacters(name))
             {
-                AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "Group input name constains special characters which is not allowed in RAPID code.");
+                AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "Group input name contains special characters which is not allowed in RAPID code.");
             }
 
             // Create the action

--- a/RobotComponents.ABB.Gh/Components/Code Generation/Instructions/WaitGOComponent.cs
+++ b/RobotComponents.ABB.Gh/Components/Code Generation/Instructions/WaitGOComponent.cs
@@ -78,9 +78,9 @@ namespace RobotComponents.ABB.Gh.Components.CodeGeneration
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "Group output name starts with a number which is not allowed in RAPID code.");
             }
-            if (HelperMethods.StringStartsWithNumber(name))
+            if (HelperMethods.StringHasSpecialCharacters(name))
             {
-                AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "Group output name constains special characters which is not allowed in RAPID code.");
+                AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "Group output name contains special characters which is not allowed in RAPID code.");
             }
 
             // Create the action


### PR DESCRIPTION
## Summary
- The second name-validation `if` block in 11 GH instruction components duplicated `StringStartsWithNumber()` instead of calling `StringHasSpecialCharacters()`, so signal/module names with special characters were never flagged
- Also fixes "constains" typo to "contains" in all warning messages

## Affected components
`WaitDI`, `WaitDO`, `WaitAI`, `WaitAO`, `WaitGI`, `WaitGO`, `SetDigitalOutput`, `SetAnalogOutput`, `SetGroupOutput`, `PulseDigitalOutput`, `LoadModule`

## Test plan
- [ ] Verify components now warn when signal names contain special characters (e.g. `my-signal!`)
- [ ] Verify the "starts with number" check still works independently