### PR TITLE
Fix IK component menu toggling wrong field

### DIFF
--- a/RobotComponents.ABB.Gh/Components/Simulation/InverseKinematicsComponent.cs
+++ b/RobotComponents.ABB.Gh/Components/Simulation/InverseKinematicsComponent.cs
@@ -352,11 +352,11 @@ namespace RobotComponents.ABB.Gh.Components.Simulation
         private void MenuItemClickOutputPlanes(object sender, EventArgs e)
         {
             RecordUndoEvent("Output Posed Axis Planes");
-            _outputMeshParameter = !_outputMeshParameter;
+            _outputPosedPlanesParameter = !_outputPosedPlanesParameter;
             AddOutputParameter(2);
 
             // Disable default mesh preview
-            if (_outputMeshParameter == true)
+            if (_outputPosedPlanesParameter == true)
             {
                 IGH_Param param = Params.Output.Find(x => x.NickName.Equality(_variableOutputParameters[2].NickName));
 


### PR DESCRIPTION
## Summary
- `MenuItemClickOutputPlanes` was toggling `_outputMeshParameter` instead of `_outputPosedPlanesParameter`
- This caused the "Output Posed Axis Planes" menu item to control the mesh toggle instead, and the planes output was never actually toggled

## Test plan
- [ ] Right-click IK component → toggle "Output Posed Axis Planes" → verify planes output appears
- [ ] Verify "Output Posed Meshes" still works independently