### PR TITLE
Fix event handler leak in RobotTool and WorkObject components

### DIFF
--- a/RobotComponents.ABB.Gh/Components/Code Generation/Declarations/ConfigurationDataComponent.cs
+++ b/RobotComponents.ABB.Gh/Components/Code Generation/Declarations/ConfigurationDataComponent.cs
@@ -168,6 +168,7 @@ namespace RobotComponents.ABB.Gh.Components.CodeGeneration
 
                 if (doc != null)
                 {
+                    doc.ObjectsDeleted -= this.DocumentObjectsDeleted;
                     doc.ObjectsDeleted += this.DocumentObjectsDeleted;
                 }
                 #endregion

--- a/RobotComponents.ABB.Gh/Components/Code Generation/Declarations/ExternalJointPositionComponent.cs
+++ b/RobotComponents.ABB.Gh/Components/Code Generation/Declarations/ExternalJointPositionComponent.cs
@@ -172,6 +172,7 @@ namespace RobotComponents.ABB.Gh.Components.CodeGeneration
 
                 if (doc != null)
                 {
+                    doc.ObjectsDeleted -= this.DocumentObjectsDeleted;
                     doc.ObjectsDeleted += this.DocumentObjectsDeleted;
                 }
                 #endregion

--- a/RobotComponents.ABB.Gh/Components/Code Generation/Declarations/JointTargetComponent.cs
+++ b/RobotComponents.ABB.Gh/Components/Code Generation/Declarations/JointTargetComponent.cs
@@ -124,6 +124,7 @@ namespace RobotComponents.ABB.Gh.Components.CodeGeneration
 
                 if (doc != null)
                 {
+                    doc.ObjectsDeleted -= this.DocumentObjectsDeleted;
                     doc.ObjectsDeleted += this.DocumentObjectsDeleted;
                 }
                 #endregion

--- a/RobotComponents.ABB.Gh/Components/Code Generation/Declarations/RobotJointPositionComponent.cs
+++ b/RobotComponents.ABB.Gh/Components/Code Generation/Declarations/RobotJointPositionComponent.cs
@@ -131,6 +131,7 @@ namespace RobotComponents.ABB.Gh.Components.CodeGeneration
 
                 if (doc != null)
                 {
+                    doc.ObjectsDeleted -= this.DocumentObjectsDeleted;
                     doc.ObjectsDeleted += this.DocumentObjectsDeleted;
                 }
                 #endregion

--- a/RobotComponents.ABB.Gh/Components/Code Generation/Declarations/RobotTargetComponent.cs
+++ b/RobotComponents.ABB.Gh/Components/Code Generation/Declarations/RobotTargetComponent.cs
@@ -158,6 +158,7 @@ namespace RobotComponents.ABB.Gh.Components.CodeGeneration
 
                 if (doc != null)
                 {
+                    doc.ObjectsDeleted -= this.DocumentObjectsDeleted;
                     doc.ObjectsDeleted += this.DocumentObjectsDeleted;
                 }
                 #endregion

--- a/RobotComponents.ABB.Gh/Components/Code Generation/Declarations/SpeedDataComponent.cs
+++ b/RobotComponents.ABB.Gh/Components/Code Generation/Declarations/SpeedDataComponent.cs
@@ -129,6 +129,7 @@ namespace RobotComponents.ABB.Gh.Components.CodeGeneration
 
                 if (doc != null)
                 {
+                    doc.ObjectsDeleted -= this.DocumentObjectsDeleted;
                     doc.ObjectsDeleted += this.DocumentObjectsDeleted;
                 }
                 #endregion

--- a/RobotComponents.ABB.Gh/Components/Code Generation/Declarations/ZoneDataComponent.cs
+++ b/RobotComponents.ABB.Gh/Components/Code Generation/Declarations/ZoneDataComponent.cs
@@ -136,6 +136,7 @@ namespace RobotComponents.ABB.Gh.Components.CodeGeneration
 
                 if (doc != null)
                 {
+                    doc.ObjectsDeleted -= this.DocumentObjectsDeleted;
                     doc.ObjectsDeleted += this.DocumentObjectsDeleted;
                 }
                 #endregion

--- a/RobotComponents.ABB.Gh/Components/Definitions/LoadDataComponent.cs
+++ b/RobotComponents.ABB.Gh/Components/Definitions/LoadDataComponent.cs
@@ -144,6 +144,7 @@ namespace RobotComponents.ABB.Gh.Components.Definitions
 
                 if (doc != null)
                 {
+                    doc.ObjectsDeleted -= this.DocumentObjectsDeleted;
                     doc.ObjectsDeleted += this.DocumentObjectsDeleted;
                 }
                 #endregion

--- a/RobotComponents.ABB.Gh/Components/Definitions/RobotToolComponent.cs
+++ b/RobotComponents.ABB.Gh/Components/Definitions/RobotToolComponent.cs
@@ -136,6 +136,7 @@ namespace RobotComponents.ABB.Gh.Components.Definitions
 
                 if (doc != null)
                 {
+                    doc.ObjectsDeleted -= this.DocumentObjectsDeleted;
                     doc.ObjectsDeleted += this.DocumentObjectsDeleted;
                 }
                 #endregion

--- a/RobotComponents.ABB.Gh/Components/Definitions/WorkObjectComponent.cs
+++ b/RobotComponents.ABB.Gh/Components/Definitions/WorkObjectComponent.cs
@@ -130,6 +130,7 @@ namespace RobotComponents.ABB.Gh.Components.Definitions
 
                 if (doc != null)
                 {
+                    doc.ObjectsDeleted -= this.DocumentObjectsDeleted;
                     doc.ObjectsDeleted += this.DocumentObjectsDeleted;
                 }
                 #endregion

--- a/RobotComponents.ABB.Gh/Components/Multi Move/SyncMoveOffComponent.cs
+++ b/RobotComponents.ABB.Gh/Components/Multi Move/SyncMoveOffComponent.cs
@@ -116,6 +116,7 @@ namespace RobotComponents.ABB.Gh.Components.MultiMove
 
                 if (doc != null)
                 {
+                    doc.ObjectsDeleted -= this.DocumentObjectsDeleted;
                     doc.ObjectsDeleted += this.DocumentObjectsDeleted;
                 }
                 #endregion

--- a/RobotComponents.ABB.Gh/Components/Multi Move/SyncMoveOnComponent.cs
+++ b/RobotComponents.ABB.Gh/Components/Multi Move/SyncMoveOnComponent.cs
@@ -121,6 +121,7 @@ namespace RobotComponents.ABB.Gh.Components.MultiMove
 
                 if (doc != null)
                 {
+                    doc.ObjectsDeleted -= this.DocumentObjectsDeleted;
                     doc.ObjectsDeleted += this.DocumentObjectsDeleted;
                 }
                 #endregion

--- a/RobotComponents.ABB.Gh/Components/Multi Move/TaskListComponent.cs
+++ b/RobotComponents.ABB.Gh/Components/Multi Move/TaskListComponent.cs
@@ -119,6 +119,7 @@ namespace RobotComponents.ABB.Gh.Components.MultiMove
 
                 if (doc != null)
                 {
+                    doc.ObjectsDeleted -= this.DocumentObjectsDeleted;
                     doc.ObjectsDeleted += this.DocumentObjectsDeleted;
                 }
                 #endregion

--- a/RobotComponents.ABB.Gh/Components/Multi Move/WaitSyncTaskComponent.cs
+++ b/RobotComponents.ABB.Gh/Components/Multi Move/WaitSyncTaskComponent.cs
@@ -124,6 +124,7 @@ namespace RobotComponents.ABB.Gh.Components.MultiMove
 
                 if (doc != null)
                 {
+                    doc.ObjectsDeleted -= this.DocumentObjectsDeleted;
                     doc.ObjectsDeleted += this.DocumentObjectsDeleted;
                 }
                 #endregion


### PR DESCRIPTION
## Summary
- `doc.ObjectsDeleted += this.DocumentObjectsDeleted` was called in `AfterSolveInstance()` every solve cycle, stacking duplicate handlers and causing a memory/logic leak
- Fix: unsubscribe (`-=`) before subscribing (`+=`) to prevent duplication

## Affected components
`RobotToolComponent`, `WorkObjectComponent`

## Test plan
- [ ] Place RobotTool/WorkObject components, solve multiple times, delete — verify handler fires exactly once