### PR TITLE
Fix serialization key/type mismatches in Wait* instructions

### DIFF
--- a/RobotComponents.ABB/Actions/Instructions/WaitAO.cs
+++ b/RobotComponents.ABB/Actions/Instructions/WaitAO.cs
@@ -62,7 +62,7 @@ namespace RobotComponents.ABB.Actions.Instructions
             info.AddValue("Version", VersionNumbering.Version, typeof(Version));
             info.AddValue("Name", _name, typeof(string));
             info.AddValue("Value", _value, typeof(double));
-            info.AddValue("Inequality Symbol", _value, typeof(InequalitySymbol));
+            info.AddValue("Inequality Symbol", _inequalitySymbol, typeof(InequalitySymbol));
             info.AddValue("Max Time", _maxTime, typeof(double));
         }
         #endregion

--- a/RobotComponents.ABB/Actions/Instructions/WaitDI.cs
+++ b/RobotComponents.ABB/Actions/Instructions/WaitDI.cs
@@ -64,7 +64,7 @@ namespace RobotComponents.ABB.Actions.Instructions
             info.AddValue("Name", _name, typeof(string));
             info.AddValue("Value", _value, typeof(bool));
             info.AddValue("Max Time", _maxTime, typeof(double));
-            info.AddValue("Time Flag", _timeFlag, typeof(double));
+            info.AddValue("Time Flag", _timeFlag, typeof(bool));
         }
         #endregion
 

--- a/RobotComponents.ABB/Actions/Instructions/WaitDO.cs
+++ b/RobotComponents.ABB/Actions/Instructions/WaitDO.cs
@@ -62,7 +62,7 @@ namespace RobotComponents.ABB.Actions.Instructions
             info.AddValue("Name", _name, typeof(string));
             info.AddValue("Value", _value, typeof(bool));
             info.AddValue("Max Time", _maxTime, typeof(double));
-            info.AddValue("Time Flag", _timeFlag, typeof(double));
+            info.AddValue("Time Flag", _timeFlag, typeof(bool));
         }
         #endregion
 

--- a/RobotComponents.ABB/Actions/Instructions/WaitTime.cs
+++ b/RobotComponents.ABB/Actions/Instructions/WaitTime.cs
@@ -58,7 +58,7 @@ namespace RobotComponents.ABB.Actions.Instructions
         {
             info.AddValue("Version", VersionNumbering.Version, typeof(Version));
             info.AddValue("Duration", _duration, typeof(double));
-            info.AddValue("In Postion", _inPosition, typeof(bool));
+            info.AddValue("In Position", _inPosition, typeof(bool));
         }
         #endregion
 


### PR DESCRIPTION
## Summary
- `WaitTime`: `GetObjectData` wrote key `"In Postion"` (typo) but deserialization reads `"In Position"` — field lost on round-trip
- `WaitDI`/`WaitDO`: `_timeFlag` (bool) was serialized with `typeof(double)` — type mismatch on deserialization
- `WaitAO`: `"Inequality Symbol"` entry serialized `_value` (the double) instead of `_inequalitySymbol` — wrong data stored

## Test plan
- [ ] Serialize/deserialize each Wait* instruction and verify all fields survive the round-trip