### PR TITLE
Fix WaitAO copy constructor dropping inequality symbol

### DIFF
--- a/RobotComponents.ABB/Actions/Instructions/WaitAI.cs
+++ b/RobotComponents.ABB/Actions/Instructions/WaitAI.cs
@@ -97,6 +97,7 @@ namespace RobotComponents.ABB.Actions.Instructions
         {
             _name = WaitAI.Name;
             _value = WaitAI.Value;
+            _inequalitySymbol = WaitAI.InequalitySymbol;
             _maxTime = WaitAI.MaxTime;
         }
 

--- a/RobotComponents.ABB/Actions/Instructions/WaitAO.cs
+++ b/RobotComponents.ABB/Actions/Instructions/WaitAO.cs
@@ -98,6 +98,7 @@ namespace RobotComponents.ABB.Actions.Instructions
         {
             _name = waitAO.Name;
             _value = waitAO.Value;
+            _inequalitySymbol = waitAO.InequalitySymbol;
             _maxTime = waitAO.MaxTime;
         }
 


### PR DESCRIPTION
## Summary
- `WaitAO` copy constructor copied `_name`, `_value`, `_maxTime` but omitted `_inequalitySymbol`
- `Duplicate()` / `DuplicateInstruction()` would silently reset the inequality symbol to the default enum value

## Test plan
- [ ] Create a WaitAO with a non-default inequality symbol, duplicate it, verify symbol is preserved