### PR TITLE
Fix RobotTool.DuplicateWithoutMesh leaving _mesh null

### DIFF
--- a/RobotComponents.ABB/Definitions/RobotTool.cs
+++ b/RobotComponents.ABB/Definitions/RobotTool.cs
@@ -220,7 +220,7 @@ namespace RobotComponents.ABB.Definitions
             _loadData = robotTool.LoadData.Duplicate();
             
             if (duplicateMesh == true) { _mesh = robotTool.Mesh.DuplicateMesh(); }
-            else { } //_mesh = new Mesh(); }
+            else { _mesh = new Mesh(); }
             
             Initialize();
         }


### PR DESCRIPTION
## Summary
- The copy constructor's `else` branch (when `duplicateMesh = false`) had the `_mesh = new Mesh()` assignment commented out
- This left `_mesh` null, causing `NullReferenceException` when `Transform()` or other mesh-dependent methods were called on the duplicate

## Test plan
- [ ] Call `DuplicateWithoutMesh()` and verify the returned tool can be transformed without exception