### PR TITLE
Fix RobotComponent outputting empty robot on construction failure

### DIFF
--- a/RobotComponents.ABB.Gh/Components/Definitions/RobotComponent.cs
+++ b/RobotComponents.ABB.Gh/Components/Definitions/RobotComponent.cs
@@ -116,6 +116,7 @@ namespace RobotComponents.ABB.Gh.Components.Definitions
             catch (Exception ex)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, ex.Message);
+                return;
             }
 
             // Output


### PR DESCRIPTION
## Summary
- The catch block in `SolveInstance` logged the error but didn't `return`, so an empty `Robot()` was output downstream
- Downstream components would receive an invalid robot with no useful error indication

## Test plan
- [ ] Provide invalid inputs to Robot component → verify no output is set and error message displays