### PR TITLE
Fix RunProgram/StopProgram missing try/finally for master.Release()

### DIFF
--- a/RobotComponents.ABB.Controllers/Controller.cs
+++ b/RobotComponents.ABB.Controllers/Controller.cs
@@ -1423,9 +1423,9 @@ namespace RobotComponents.ABB.Controllers
             #region load module from directory
             using (ControllersNS.Mastership master = ControllersNS.Mastership.Request(_controller))
             {
-                foreach (string filePathRemote in remotefilePaths)
+                try
                 {
-                    try
+                    foreach (string filePathRemote in remotefilePaths)
                     {
                         // Grant acces
                         _controller.AuthenticationSystem.DemandGrant(ControllersNS.Grant.LoadRapidProgram);
@@ -1436,14 +1436,17 @@ namespace RobotComponents.ABB.Controllers
                         status = "Loaded a module from the filesystem of the controller to the controller task.";
                         Log(status);
                     }
-                    catch (Exception e)
-                    {
-                        status = $"Could not load the module from the filesystem of the controller to the controller task: {e.Message}.";
-                        Log(status);
-                        return false;
-                    }
                 }
-                master.Release();
+                catch (Exception e)
+                {
+                    status = $"Could not load the module from the filesystem of the controller to the controller task: {e.Message}.";
+                    Log(status);
+                    return false;
+                }
+                finally
+                {
+                    master.Release();
+                }
             }
             #endregion
 

--- a/RobotComponents.ABB.Controllers/Controller.cs
+++ b/RobotComponents.ABB.Controllers/Controller.cs
@@ -1953,8 +1953,14 @@ namespace RobotComponents.ABB.Controllers
             {
                 using (ControllersNS.Mastership master = ControllersNS.Mastership.Request(_controller))
                 {
-                    _controller.Rapid.Start(RapidDomainNS.RegainMode.Continue, RapidDomainNS.ExecutionMode.Continuous, RapidDomainNS.ExecutionCycle.Once, RapidDomainNS.StartCheck.CallChain);
-                    master.Release();
+                    try
+                    {
+                        _controller.Rapid.Start(RapidDomainNS.RegainMode.Continue, RapidDomainNS.ExecutionMode.Continuous, RapidDomainNS.ExecutionCycle.Once, RapidDomainNS.StartCheck.CallChain);
+                    }
+                    finally
+                    {
+                        master.Release();
+                    }
                 }
 
                 status = "Program started.";
@@ -1990,8 +1996,14 @@ namespace RobotComponents.ABB.Controllers
             {
                 using (ControllersNS.Mastership master = ControllersNS.Mastership.Request(_controller))
                 {
-                    _controller.Rapid.Stop(RapidDomainNS.StopMode.Instruction);
-                    master.Release();
+                    try
+                    {
+                        _controller.Rapid.Stop(RapidDomainNS.StopMode.Instruction);
+                    }
+                    finally
+                    {
+                        master.Release();
+                    }
                 }
 
                 status = "Program stopped.";


### PR DESCRIPTION
## Summary
- If `Rapid.Start()` or `Rapid.Stop()` threw an exception, `master.Release()` was never called, leaving the controller mastership locked indefinitely
- Wrapped both in try/finally to ensure release, matching the existing pattern in `ResetProgramPointers()`

## Test plan
- [ ] Verify RunProgram/StopProgram still work normally
- [ ] Verify mastership is released even if Rapid.Start/Stop fails (e.g., controller in wrong state)