### PR TITLE
Add Phase 2b tests: Movement gaps + RobotJointPosition

### DIFF
--- a/RobotComponents.Tests/Actions/MovementTests.cs
+++ b/RobotComponents.Tests/Actions/MovementTests.cs
@@ -159,6 +159,34 @@ namespace RobotComponents.Tests.Actions
         }
         #endregion
 
+        #region MoveC
+        [Fact]
+        [Trait("Category", "RequiresRhino")]
+        public void MoveC_RobotTarget_ProducesCorrectInstruction()
+        {
+            RobotTarget cirPoint = new RobotTarget("via1", new Plane(new Point3d(200, 100, 400), Vector3d.ZAxis));
+            RobotTarget target = new RobotTarget("rt1", new Plane(new Point3d(300, 0, 500), Vector3d.ZAxis));
+            Movement move = new Movement(MovementType.MoveC, target, new SpeedData(100), new ZoneData(10));
+            move.CircularPoint = cirPoint;
+
+            List<string> module = GenerateModule(new List<IAction> { move });
+            string joined = string.Join(Environment.NewLine, module);
+
+            Assert.Contains("MoveC", joined);
+            Assert.Contains("via1", joined);
+        }
+
+        [Fact]
+        [Trait("Category", "RequiresRhino")]
+        public void MoveC_UnsetCircularPoint_ThrowsException()
+        {
+            RobotTarget target = new RobotTarget("rt1", new Plane(new Point3d(300, 0, 500), Vector3d.ZAxis));
+            Movement move = new Movement(MovementType.MoveC, target, new SpeedData(100), new ZoneData(10));
+
+            Assert.Throws<Exception>(() => GenerateModule(new List<IAction> { move }));
+        }
+        #endregion
+
         #region IsValid
         [Fact]
         [Trait("Category", "RequiresRhino")]

--- a/RobotComponents.Tests/Actions/MovementTests.cs
+++ b/RobotComponents.Tests/Actions/MovementTests.cs
@@ -265,6 +265,35 @@ namespace RobotComponents.Tests.Actions
         }
         #endregion
 
+        #region Time
+        [Fact]
+        [Trait("Category", "RequiresRhino")]
+        public void MoveL_WithTime_AppendsBackslashT()
+        {
+            RobotTarget target = new RobotTarget("rt1", new Plane(new Point3d(300, 0, 500), Vector3d.ZAxis));
+            Movement move = new Movement(MovementType.MoveL, target, new SpeedData(100), new ZoneData(10));
+            move.Time = 2.5;
+
+            List<string> module = GenerateModule(new List<IAction> { move });
+            string joined = string.Join(Environment.NewLine, module);
+
+            Assert.Contains("\\T:=2.5", joined);
+        }
+
+        [Fact]
+        [Trait("Category", "RequiresRhino")]
+        public void MoveL_DefaultTime_NoBackslashT()
+        {
+            RobotTarget target = new RobotTarget("rt1", new Plane(new Point3d(300, 0, 500), Vector3d.ZAxis));
+            Movement move = new Movement(MovementType.MoveL, target, new SpeedData(100), new ZoneData(10));
+
+            List<string> module = GenerateModule(new List<IAction> { move });
+            string joined = string.Join(Environment.NewLine, module);
+
+            Assert.DoesNotContain("\\T", joined);
+        }
+        #endregion
+
         #region IsValid
         [Fact]
         [Trait("Category", "RequiresRhino")]

--- a/RobotComponents.Tests/Actions/MovementTests.cs
+++ b/RobotComponents.Tests/Actions/MovementTests.cs
@@ -236,6 +236,35 @@ namespace RobotComponents.Tests.Actions
         }
         #endregion
 
+        #region SyncID
+        [Fact]
+        [Trait("Category", "RequiresRhino")]
+        public void MoveL_WithSyncID_AppendsBackslashID()
+        {
+            RobotTarget target = new RobotTarget("rt1", new Plane(new Point3d(300, 0, 500), Vector3d.ZAxis));
+            Movement move = new Movement(MovementType.MoveL, target, new SpeedData(100), new ZoneData(10));
+            move.SyncID = 5;
+
+            List<string> module = GenerateModule(new List<IAction> { move });
+            string joined = string.Join(Environment.NewLine, module);
+
+            Assert.Contains("\\ID:=5", joined);
+        }
+
+        [Fact]
+        [Trait("Category", "RequiresRhino")]
+        public void MoveL_DefaultSyncID_NoBackslashID()
+        {
+            RobotTarget target = new RobotTarget("rt1", new Plane(new Point3d(300, 0, 500), Vector3d.ZAxis));
+            Movement move = new Movement(MovementType.MoveL, target, new SpeedData(100), new ZoneData(10));
+
+            List<string> module = GenerateModule(new List<IAction> { move });
+            string joined = string.Join(Environment.NewLine, module);
+
+            Assert.DoesNotContain("\\ID", joined);
+        }
+        #endregion
+
         #region IsValid
         [Fact]
         [Trait("Category", "RequiresRhino")]

--- a/RobotComponents.Tests/Actions/MovementTests.cs
+++ b/RobotComponents.Tests/Actions/MovementTests.cs
@@ -172,7 +172,7 @@ namespace RobotComponents.Tests.Actions
             List<string> module = GenerateModule(new List<IAction> { move });
             string joined = string.Join(Environment.NewLine, module);
 
-            Assert.Contains("MoveC", joined);
+            Assert.Contains("MoveC ", joined);
             Assert.Contains("via1", joined);
         }
 
@@ -187,7 +187,7 @@ namespace RobotComponents.Tests.Actions
         }
         #endregion
 
-        #region MoveLDO / MoveJDO
+        #region MoveLDO / MoveJDO / MoveCDO
         [Fact]
         [Trait("Category", "RequiresRhino")]
         public void MoveL_WithDigitalOutput_ProducesMoveLDO()
@@ -200,7 +200,7 @@ namespace RobotComponents.Tests.Actions
             string joined = string.Join(Environment.NewLine, module);
 
             Assert.Contains("MoveLDO", joined);
-            Assert.Contains("DO_1", joined);
+            Assert.Contains("DO_1, 1", joined);
         }
 
         [Fact]
@@ -233,6 +233,24 @@ namespace RobotComponents.Tests.Actions
             Assert.Contains("MoveAbsJ", joined);
             Assert.Contains("SetDO", joined);
             Assert.Contains("DO_1", joined);
+        }
+
+        [Fact]
+        [Trait("Category", "RequiresRhino")]
+        public void MoveC_WithDigitalOutput_ProducesMoveCDO()
+        {
+            RobotTarget cirPoint = new RobotTarget("via1", new Plane(new Point3d(200, 100, 400), Vector3d.ZAxis));
+            RobotTarget target = new RobotTarget("rt1", new Plane(new Point3d(300, 0, 500), Vector3d.ZAxis));
+            SetDigitalOutput sdo = new SetDigitalOutput("DO_1", true);
+            Movement move = new Movement(MovementType.MoveC, target, new SpeedData(100), new ZoneData(10), sdo);
+            move.CircularPoint = cirPoint;
+
+            List<string> module = GenerateModule(new List<IAction> { move });
+            string joined = string.Join(Environment.NewLine, module);
+
+            Assert.Contains("MoveCDO", joined);
+            Assert.Contains("via1", joined);
+            Assert.Contains("DO_1, 1", joined);
         }
         #endregion
 

--- a/RobotComponents.Tests/Actions/MovementTests.cs
+++ b/RobotComponents.Tests/Actions/MovementTests.cs
@@ -187,6 +187,55 @@ namespace RobotComponents.Tests.Actions
         }
         #endregion
 
+        #region MoveLDO / MoveJDO
+        [Fact]
+        [Trait("Category", "RequiresRhino")]
+        public void MoveL_WithDigitalOutput_ProducesMoveLDO()
+        {
+            RobotTarget target = new RobotTarget("rt1", new Plane(new Point3d(300, 0, 500), Vector3d.ZAxis));
+            SetDigitalOutput sdo = new SetDigitalOutput("DO_1", true);
+            Movement move = new Movement(MovementType.MoveL, target, new SpeedData(100), new ZoneData(10), sdo);
+
+            List<string> module = GenerateModule(new List<IAction> { move });
+            string joined = string.Join(Environment.NewLine, module);
+
+            Assert.Contains("MoveLDO", joined);
+            Assert.Contains("DO_1", joined);
+        }
+
+        [Fact]
+        [Trait("Category", "RequiresRhino")]
+        public void MoveJ_WithDigitalOutput_ProducesMoveJDO()
+        {
+            RobotTarget target = new RobotTarget("rt1", new Plane(new Point3d(300, 0, 500), Vector3d.ZAxis));
+            SetDigitalOutput sdo = new SetDigitalOutput("DO_1", false);
+            Movement move = new Movement(MovementType.MoveJ, target, new SpeedData(100), new ZoneData(10), sdo);
+
+            List<string> module = GenerateModule(new List<IAction> { move });
+            string joined = string.Join(Environment.NewLine, module);
+
+            Assert.Contains("MoveJDO", joined);
+            Assert.Contains("DO_1", joined);
+        }
+
+        [Fact]
+        [Trait("Category", "RequiresRhino")]
+        public void MoveAbsJ_WithDigitalOutput_ProducesSeparateSetDO()
+        {
+            RobotJointPosition rjp = new RobotJointPosition(0, 0, 0, 0, 0, 0);
+            JointTarget target = new JointTarget("jt1", rjp);
+            SetDigitalOutput sdo = new SetDigitalOutput("DO_1", true);
+            Movement move = new Movement(MovementType.MoveAbsJ, target, new SpeedData(100), new ZoneData(10), sdo);
+
+            List<string> module = GenerateModule(new List<IAction> { move });
+            string joined = string.Join(Environment.NewLine, module);
+
+            Assert.Contains("MoveAbsJ", joined);
+            Assert.Contains("SetDO", joined);
+            Assert.Contains("DO_1", joined);
+        }
+        #endregion
+
         #region IsValid
         [Fact]
         [Trait("Category", "RequiresRhino")]

--- a/RobotComponents.Tests/Actions/RobotJointPositionTests.cs
+++ b/RobotComponents.Tests/Actions/RobotJointPositionTests.cs
@@ -6,6 +6,7 @@
 
 // System Libs
 using System;
+using System.Collections.Generic;
 // Xunit Libs
 using Xunit;
 // Robot Components Libs
@@ -58,6 +59,19 @@ namespace RobotComponents.Tests.Actions
 
             Assert.Equal(0, rjp[0]);
         }
+
+        [Fact]
+        public void Constructor_ListOfDoubles_SetsValues()
+        {
+            RobotJointPosition rjp = new RobotJointPosition(new List<double> { 10, 20, 30, 40, 50, 60 });
+
+            Assert.Equal(10, rjp[0]);
+            Assert.Equal(20, rjp[1]);
+            Assert.Equal(30, rjp[2]);
+            Assert.Equal(40, rjp[3]);
+            Assert.Equal(50, rjp[4]);
+            Assert.Equal(60, rjp[5]);
+        }
         #endregion
 
         #region ToRAPID
@@ -93,6 +107,24 @@ namespace RobotComponents.Tests.Actions
             RobotJointPosition rjp = new RobotJointPosition(10, 20, 30, 40, 50, 60);
 
             Assert.Equal(string.Empty, rjp.ToRAPIDDeclaration(null));
+        }
+
+        [Fact]
+        public void ToRAPIDDeclaration_LocalScope_IncludesScopePrefix()
+        {
+            RobotJointPosition rjp = new RobotJointPosition("rj1", 0, 0, 0, 0, 0, 0);
+            rjp.Scope = Scope.LOCAL;
+
+            Assert.Equal("LOCAL VAR robjoint rj1 := [0, 0, 0, 0, 0, 0];", rjp.ToRAPIDDeclaration(null));
+        }
+
+        [Fact]
+        public void ToRAPIDDeclaration_TaskScope_IncludesScopePrefix()
+        {
+            RobotJointPosition rjp = new RobotJointPosition("rj1", 0, 0, 0, 0, 0, 0);
+            rjp.Scope = Scope.TASK;
+
+            Assert.Equal("TASK VAR robjoint rj1 := [0, 0, 0, 0, 0, 0];", rjp.ToRAPIDDeclaration(null));
         }
         #endregion
 

--- a/RobotComponents.Tests/Actions/RobotJointPositionTests.cs
+++ b/RobotComponents.Tests/Actions/RobotJointPositionTests.cs
@@ -1,0 +1,203 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This file is part of Robot Components
+// Project: https://github.com/RobotComponents/RobotComponents
+//
+// For license details, see the LICENSE file in the project root.
+
+// System Libs
+using System;
+// Xunit Libs
+using Xunit;
+// Robot Components Libs
+using RobotComponents.ABB.Actions.Declarations;
+using RobotComponents.ABB.Enumerations;
+
+namespace RobotComponents.Tests.Actions
+{
+    public class RobotJointPositionTests
+    {
+        #region Constructor
+        [Fact]
+        public void Constructor_Default_AllZero()
+        {
+            RobotJointPosition rjp = new RobotJointPosition();
+
+            for (int i = 0; i < 6; i++)
+            {
+                Assert.Equal(0, rjp[i]);
+            }
+        }
+
+        [Fact]
+        public void Constructor_SixArgs_SetsValues()
+        {
+            RobotJointPosition rjp = new RobotJointPosition(10, 20, 30, 40, 50, 60);
+
+            Assert.Equal(10, rjp[0]);
+            Assert.Equal(20, rjp[1]);
+            Assert.Equal(30, rjp[2]);
+            Assert.Equal(40, rjp[3]);
+            Assert.Equal(50, rjp[4]);
+            Assert.Equal(60, rjp[5]);
+        }
+
+        [Fact]
+        public void Constructor_Named_SetsNameAndValues()
+        {
+            RobotJointPosition rjp = new RobotJointPosition("rj1", 10, 20, 30, 40, 50, 60);
+
+            Assert.Equal("rj1", rjp.Name);
+            Assert.Equal(10, rjp[0]);
+            Assert.Equal(60, rjp[5]);
+        }
+
+        [Fact]
+        public void Constructor_NaN_ReplacedWithZero()
+        {
+            RobotJointPosition rjp = new RobotJointPosition(double.NaN);
+
+            Assert.Equal(0, rjp[0]);
+        }
+        #endregion
+
+        #region ToRAPID
+        [Fact]
+        public void ToRAPID_AllZero_ReturnsBracketFormat()
+        {
+            RobotJointPosition rjp = new RobotJointPosition();
+
+            Assert.Equal("[0, 0, 0, 0, 0, 0]", rjp.ToRAPID());
+        }
+
+        [Fact]
+        public void ToRAPID_DecimalValues_FormatsCorrectly()
+        {
+            RobotJointPosition rjp = new RobotJointPosition(10.5, 20, 30.75, 0, 0, 0);
+
+            Assert.Equal("[10.5, 20, 30.75, 0, 0, 0]", rjp.ToRAPID());
+        }
+        #endregion
+
+        #region ToRAPIDDeclaration
+        [Fact]
+        public void ToRAPIDDeclaration_Named_ReturnsRobjointDeclaration()
+        {
+            RobotJointPosition rjp = new RobotJointPosition("rj1", 10, 20, 30, 40, 50, 60);
+
+            Assert.Equal("VAR robjoint rj1 := [10, 20, 30, 40, 50, 60];", rjp.ToRAPIDDeclaration(null));
+        }
+
+        [Fact]
+        public void ToRAPIDDeclaration_Unnamed_ReturnsEmpty()
+        {
+            RobotJointPosition rjp = new RobotJointPosition(10, 20, 30, 40, 50, 60);
+
+            Assert.Equal(string.Empty, rjp.ToRAPIDDeclaration(null));
+        }
+        #endregion
+
+        #region ToRAPIDInstruction
+        [Fact]
+        public void ToRAPIDInstruction_ReturnsEmpty()
+        {
+            RobotJointPosition rjp = new RobotJointPosition("rj1", 10, 20, 30, 40, 50, 60);
+
+            Assert.Equal(string.Empty, rjp.ToRAPIDInstruction(null));
+        }
+        #endregion
+
+        #region Indexer
+        [Fact]
+        public void Indexer_SetAndGet_RoundTrips()
+        {
+            RobotJointPosition rjp = new RobotJointPosition();
+            rjp[0] = 42;
+
+            Assert.Equal(42, rjp[0]);
+        }
+
+        [Fact]
+        public void Indexer_OutOfRange_Throws()
+        {
+            RobotJointPosition rjp = new RobotJointPosition();
+
+            Assert.Throws<IndexOutOfRangeException>(() => { double _ = rjp[6]; });
+        }
+        #endregion
+
+        #region IsValid
+        [Fact]
+        public void IsValid_AllZero_ReturnsTrue()
+        {
+            RobotJointPosition rjp = new RobotJointPosition();
+
+            Assert.True(rjp.IsValid);
+        }
+
+        [Fact]
+        public void IsValid_WithValues_ReturnsTrue()
+        {
+            RobotJointPosition rjp = new RobotJointPosition(10, 20, 30, 40, 50, 60);
+
+            Assert.True(rjp.IsValid);
+        }
+        #endregion
+
+        #region Duplicate
+        [Fact]
+        public void Duplicate_ReturnsMatchingValues()
+        {
+            RobotJointPosition original = new RobotJointPosition("rj1", 10, 20, 30, 40, 50, 60);
+
+            RobotJointPosition copy = original.Duplicate();
+
+            Assert.Equal(original.Name, copy.Name);
+            for (int i = 0; i < 6; i++)
+            {
+                Assert.Equal(original[i], copy[i]);
+            }
+        }
+        #endregion
+
+        #region Parse / TryParse
+        [Fact]
+        public void Parse_ValidRapidString_ReturnsCorrectPositions()
+        {
+            RobotJointPosition rjp = RobotJointPosition.Parse("VAR robjoint rj1 := [10, 20, 30, 40, 50, 60];");
+
+            Assert.Equal("rj1", rjp.Name);
+            Assert.Equal(10, rjp[0]);
+            Assert.Equal(20, rjp[1]);
+            Assert.Equal(30, rjp[2]);
+            Assert.Equal(40, rjp[3]);
+            Assert.Equal(50, rjp[4]);
+            Assert.Equal(60, rjp[5]);
+        }
+
+        [Fact]
+        public void TryParse_InvalidString_ReturnsFalse()
+        {
+            bool result = RobotJointPosition.TryParse("garbage", out RobotJointPosition rjp);
+
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void TryParse_WrongDatatype_ReturnsFalse()
+        {
+            bool result = RobotJointPosition.TryParse("VAR speeddata v100 := [100, 500, 5000, 1000];", out RobotJointPosition rjp);
+
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void Parse_ConstVariableType_SetsConst()
+        {
+            RobotJointPosition rjp = RobotJointPosition.Parse("CONST robjoint rj1 := [0, 0, 0, 0, 0, 0];");
+
+            Assert.Equal(VariableType.CONST, rjp.VariableType);
+            Assert.Equal("rj1", rjp.Name);
+        }
+        #endregion
+    }
+}


### PR DESCRIPTION
## Summary
- Adds **MoveC** tests: circular via-point instruction format and unset cirPoint exception
- Adds **MoveLDO/MoveJDO** tests: MoveL/MoveJ with SetDigitalOutput and MoveAbsJ+DO separate instruction
- Adds **SyncID** (`\ID`) tests: parameter appended when set, absent by default
- Adds **Time** (`\T`) tests: parameter appended when set, absent by default
- Adds **RobotJointPositionTests.cs**: 18 tests covering constructors, ToRAPID, declarations, indexer, IsValid, Duplicate, Parse/TryParse

**27 new tests** across 5 commits (338 lines added).

## Test plan
- [x] All 221 non-Rhino tests pass locally (0 failures)
- [ ] CI confirms RequiresRhino tests pass with Rhino runtime
- [x] No regressions in existing test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)