### PR TITLE
Add Phase 3 unit tests: Definitions & Kinematics (121 tests)

### DIFF
--- a/RobotComponents.Tests/Definitions/RobotTests.cs
+++ b/RobotComponents.Tests/Definitions/RobotTests.cs
@@ -45,6 +45,7 @@ namespace RobotComponents.Tests.Definitions
 
         #region Constructor
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void Constructor_WithKinematicParameters_ProducesValidRobot()
         {
             Robot robot = CreateTestRobot();
@@ -63,6 +64,7 @@ namespace RobotComponents.Tests.Definitions
         }
 
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void Constructor_WorldXYBase_SetsBasePlane()
         {
             Robot robot = CreateTestRobot();
@@ -71,6 +73,7 @@ namespace RobotComponents.Tests.Definitions
         }
 
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void Constructor_OffsetBase_SetsBasePlane()
         {
             Plane basePlane = new Plane(new Point3d(1000, 500, 0), Vector3d.XAxis, Vector3d.YAxis);
@@ -83,6 +86,7 @@ namespace RobotComponents.Tests.Definitions
 
         #region Axis Planes
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void InternalAxisPlanes_FromKinematicParameters_HasSixPlanes()
         {
             Robot robot = CreateTestRobot();
@@ -91,6 +95,7 @@ namespace RobotComponents.Tests.Definitions
         }
 
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void InternalAxisPlanes_Axis1_AtBaseOrigin()
         {
             Robot robot = CreateTestRobot();
@@ -103,6 +108,7 @@ namespace RobotComponents.Tests.Definitions
         }
 
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void InternalAxisPlanes_Axis2_AtC1Height()
         {
             Robot robot = CreateTestRobot();
@@ -115,6 +121,7 @@ namespace RobotComponents.Tests.Definitions
         }
 
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void InternalAxisPlanes_Axis3_AtC1PlusC2Height()
         {
             Robot robot = CreateTestRobot();
@@ -128,6 +135,7 @@ namespace RobotComponents.Tests.Definitions
 
         #region Mounting Frame
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void MountingFrame_IRB120Parameters_CorrectPosition()
         {
             Robot robot = CreateTestRobot();
@@ -142,6 +150,7 @@ namespace RobotComponents.Tests.Definitions
 
         #region Tool
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void Tool_DefaultTool0_IsValid()
         {
             Robot robot = CreateTestRobot();
@@ -151,6 +160,7 @@ namespace RobotComponents.Tests.Definitions
         }
 
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void ToolPlane_DefaultTool0_AtMountingFrame()
         {
             Robot robot = CreateTestRobot();
@@ -164,6 +174,7 @@ namespace RobotComponents.Tests.Definitions
 
         #region Properties
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void NumberOfAxes_Always6()
         {
             Robot robot = CreateTestRobot();
@@ -172,6 +183,7 @@ namespace RobotComponents.Tests.Definitions
         }
 
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void InternalAxisLimits_SetCorrectly()
         {
             Robot robot = CreateTestRobot();
@@ -184,6 +196,7 @@ namespace RobotComponents.Tests.Definitions
         }
 
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void RobotKinematicParameters_Accessible()
         {
             Robot robot = CreateTestRobot();
@@ -201,6 +214,7 @@ namespace RobotComponents.Tests.Definitions
         }
 
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void ExternalAxes_DefaultEmpty()
         {
             Robot robot = CreateTestRobot();
@@ -209,6 +223,7 @@ namespace RobotComponents.Tests.Definitions
         }
 
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void Meshes_Contains8Elements()
         {
             Robot robot = CreateTestRobot();
@@ -218,6 +233,7 @@ namespace RobotComponents.Tests.Definitions
         }
 
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void InverseKinematics_Initialized()
         {
             Robot robot = CreateTestRobot();
@@ -226,6 +242,7 @@ namespace RobotComponents.Tests.Definitions
         }
 
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void ForwardKinematics_Initialized()
         {
             Robot robot = CreateTestRobot();
@@ -236,6 +253,7 @@ namespace RobotComponents.Tests.Definitions
 
         #region Duplicate
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void Duplicate_CreatesIndependentCopy()
         {
             Robot original = CreateTestRobot();
@@ -248,6 +266,7 @@ namespace RobotComponents.Tests.Definitions
         }
 
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void Duplicate_PreservesKinematicParameters()
         {
             Robot original = CreateTestRobot();
@@ -259,6 +278,7 @@ namespace RobotComponents.Tests.Definitions
         }
 
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void Duplicate_PreservesAxisLimits()
         {
             Robot original = CreateTestRobot();
@@ -272,6 +292,7 @@ namespace RobotComponents.Tests.Definitions
         }
 
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void DuplicateMechanicalUnit_ReturnsValidRobot()
         {
             Robot original = CreateTestRobot();
@@ -283,6 +304,7 @@ namespace RobotComponents.Tests.Definitions
 
         #region ToString
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void ToString_ValidRobot_IncludesName()
         {
             Robot robot = CreateTestRobot();

--- a/RobotComponents.Tests/Definitions/RobotTests.cs
+++ b/RobotComponents.Tests/Definitions/RobotTests.cs
@@ -4,9 +4,6 @@
 //
 // For license details, see the LICENSE file in the project root.
 
-// System Libs
-using System.Collections.Generic;
-using System.Linq;
 // Rhino Libs
 using Rhino.Geometry;
 // Xunit Libs
@@ -20,27 +17,9 @@ namespace RobotComponents.Tests.Definitions
     {
         private const double Tolerance = 1e-6;
 
-        /// <summary>
-        /// Creates a test robot with IRB120-3/0.58 kinematic parameters and empty meshes.
-        /// </summary>
         private static Robot CreateTestRobot(Plane basePlane = default, RobotTool tool = null)
         {
-            if (basePlane == default) basePlane = Plane.WorldXY;
-            if (tool == null) tool = new RobotTool();
-
-            List<Mesh> meshes = Enumerable.Range(0, 7).Select(_ => new Mesh()).ToList();
-            RobotKinematicParameters parameters = new RobotKinematicParameters(0, -70, 0, 0, 290, 270, 302, 72);
-            Interval[] limits = new Interval[]
-            {
-                new Interval(-165, 165),
-                new Interval(-110, 110),
-                new Interval(-110, 70),
-                new Interval(-160, 160),
-                new Interval(-120, 120),
-                new Interval(-400, 400)
-            };
-
-            return new Robot("TestRobot", meshes, parameters, limits, basePlane, tool);
+            return TestHelpers.CreateIRB120Robot(basePlane, tool);
         }
 
         #region Constructor

--- a/RobotComponents.Tests/Definitions/RobotTests.cs
+++ b/RobotComponents.Tests/Definitions/RobotTests.cs
@@ -1,0 +1,302 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This file is part of Robot Components
+// Project: https://github.com/RobotComponents/RobotComponents
+//
+// For license details, see the LICENSE file in the project root.
+
+// System Libs
+using System.Collections.Generic;
+using System.Linq;
+// Rhino Libs
+using Rhino.Geometry;
+// Xunit Libs
+using Xunit;
+// Robot Components Libs
+using RobotComponents.ABB.Definitions;
+
+namespace RobotComponents.Tests.Definitions
+{
+    public class RobotTests
+    {
+        private const double Tolerance = 1e-6;
+
+        /// <summary>
+        /// Creates a test robot with IRB120-3/0.58 kinematic parameters and empty meshes.
+        /// </summary>
+        private static Robot CreateTestRobot(Plane basePlane = default, RobotTool tool = null)
+        {
+            if (basePlane == default) basePlane = Plane.WorldXY;
+            if (tool == null) tool = new RobotTool();
+
+            List<Mesh> meshes = Enumerable.Range(0, 7).Select(_ => new Mesh()).ToList();
+            RobotKinematicParameters parameters = new RobotKinematicParameters(0, -70, 0, 0, 290, 270, 302, 72);
+            Interval[] limits = new Interval[]
+            {
+                new Interval(-165, 165),
+                new Interval(-110, 110),
+                new Interval(-110, 70),
+                new Interval(-160, 160),
+                new Interval(-120, 120),
+                new Interval(-400, 400)
+            };
+
+            return new Robot("TestRobot", meshes, parameters, limits, basePlane, tool);
+        }
+
+        #region Constructor
+        [Fact]
+        public void Constructor_WithKinematicParameters_ProducesValidRobot()
+        {
+            Robot robot = CreateTestRobot();
+
+            Assert.True(robot.IsValid);
+            Assert.Equal("TestRobot", robot.Name);
+        }
+
+        [Fact]
+        public void Constructor_Empty_ProducesInvalidRobot()
+        {
+            Robot robot = new Robot();
+
+            Assert.False(robot.IsValid);
+            Assert.Equal("Empty Robot", robot.Name);
+        }
+
+        [Fact]
+        public void Constructor_WorldXYBase_SetsBasePlane()
+        {
+            Robot robot = CreateTestRobot();
+
+            Assert.Equal(Plane.WorldXY.Origin, robot.BasePlane.Origin);
+        }
+
+        [Fact]
+        public void Constructor_OffsetBase_SetsBasePlane()
+        {
+            Plane basePlane = new Plane(new Point3d(1000, 500, 0), Vector3d.XAxis, Vector3d.YAxis);
+            Robot robot = CreateTestRobot(basePlane);
+
+            Assert.InRange(robot.BasePlane.Origin.X, 1000 - Tolerance, 1000 + Tolerance);
+            Assert.InRange(robot.BasePlane.Origin.Y, 500 - Tolerance, 500 + Tolerance);
+        }
+        #endregion
+
+        #region Axis Planes
+        [Fact]
+        public void InternalAxisPlanes_FromKinematicParameters_HasSixPlanes()
+        {
+            Robot robot = CreateTestRobot();
+
+            Assert.Equal(6, robot.InternalAxisPlanes.Length);
+        }
+
+        [Fact]
+        public void InternalAxisPlanes_Axis1_AtBaseOrigin()
+        {
+            Robot robot = CreateTestRobot();
+            Plane axis1 = robot.InternalAxisPlanes[0];
+
+            // Axis 1 origin should be at (0, 0, 0) for WorldXY base with A1=0
+            Assert.InRange(axis1.Origin.X, -Tolerance, Tolerance);
+            Assert.InRange(axis1.Origin.Y, -Tolerance, Tolerance);
+            Assert.InRange(axis1.Origin.Z, -Tolerance, Tolerance);
+        }
+
+        [Fact]
+        public void InternalAxisPlanes_Axis2_AtC1Height()
+        {
+            Robot robot = CreateTestRobot();
+            Plane axis2 = robot.InternalAxisPlanes[1];
+
+            // Axis 2 should be at (A1, 0, C1) = (0, 0, 290) for WorldXY base
+            Assert.InRange(axis2.Origin.X, -Tolerance, Tolerance);
+            Assert.InRange(axis2.Origin.Y, -Tolerance, Tolerance);
+            Assert.InRange(axis2.Origin.Z, 290 - Tolerance, 290 + Tolerance);
+        }
+
+        [Fact]
+        public void InternalAxisPlanes_Axis3_AtC1PlusC2Height()
+        {
+            Robot robot = CreateTestRobot();
+            Plane axis3 = robot.InternalAxisPlanes[2];
+
+            // Axis 3 should be at (A1, 0, C1+C2) = (0, 0, 560) for WorldXY base
+            Assert.InRange(axis3.Origin.X, -Tolerance, Tolerance);
+            Assert.InRange(axis3.Origin.Z, 560 - Tolerance, 560 + Tolerance);
+        }
+        #endregion
+
+        #region Mounting Frame
+        [Fact]
+        public void MountingFrame_IRB120Parameters_CorrectPosition()
+        {
+            Robot robot = CreateTestRobot();
+
+            // MountingFrame origin = planes[5].Origin = (A1+C3+C4, -B, C1+C2-A2-A3)
+            // = (0+302+72, 0, 290+270-(-70)-0) = (374, 0, 630)
+            Assert.InRange(robot.MountingFrame.Origin.X, 374 - Tolerance, 374 + Tolerance);
+            Assert.InRange(robot.MountingFrame.Origin.Y, -Tolerance, Tolerance);
+            Assert.InRange(robot.MountingFrame.Origin.Z, 630 - Tolerance, 630 + Tolerance);
+        }
+        #endregion
+
+        #region Tool
+        [Fact]
+        public void Tool_DefaultTool0_IsValid()
+        {
+            Robot robot = CreateTestRobot();
+
+            Assert.True(robot.Tool.IsValid);
+            Assert.Equal("tool0", robot.Tool.Name);
+        }
+
+        [Fact]
+        public void ToolPlane_DefaultTool0_AtMountingFrame()
+        {
+            Robot robot = CreateTestRobot();
+
+            // With tool0 (WorldXY attachment and tool), TCP = mounting frame position
+            Assert.InRange(robot.ToolPlane.Origin.X, 374 - Tolerance, 374 + Tolerance);
+            Assert.InRange(robot.ToolPlane.Origin.Y, -Tolerance, Tolerance);
+            Assert.InRange(robot.ToolPlane.Origin.Z, 630 - Tolerance, 630 + Tolerance);
+        }
+        #endregion
+
+        #region Properties
+        [Fact]
+        public void NumberOfAxes_Always6()
+        {
+            Robot robot = CreateTestRobot();
+
+            Assert.Equal(6, robot.NumberOfAxes);
+        }
+
+        [Fact]
+        public void InternalAxisLimits_SetCorrectly()
+        {
+            Robot robot = CreateTestRobot();
+
+            Assert.Equal(6, robot.InternalAxisLimits.Length);
+            Assert.Equal(-165, robot.InternalAxisLimits[0].T0);
+            Assert.Equal(165, robot.InternalAxisLimits[0].T1);
+            Assert.Equal(-400, robot.InternalAxisLimits[5].T0);
+            Assert.Equal(400, robot.InternalAxisLimits[5].T1);
+        }
+
+        [Fact]
+        public void RobotKinematicParameters_Accessible()
+        {
+            Robot robot = CreateTestRobot();
+            RobotKinematicParameters p = robot.RobotKinematicParameters;
+
+            Assert.True(p.IsValid);
+            Assert.Equal(0, p.A1);
+            Assert.Equal(-70, p.A2);
+            Assert.Equal(0, p.A3);
+            Assert.Equal(0, p.B);
+            Assert.Equal(290, p.C1);
+            Assert.Equal(270, p.C2);
+            Assert.Equal(302, p.C3);
+            Assert.Equal(72, p.C4);
+        }
+
+        [Fact]
+        public void ExternalAxes_DefaultEmpty()
+        {
+            Robot robot = CreateTestRobot();
+
+            Assert.Empty(robot.ExternalAxes);
+        }
+
+        [Fact]
+        public void Meshes_Contains8Elements()
+        {
+            Robot robot = CreateTestRobot();
+
+            // 7 robot body meshes + 1 tool mesh = 8
+            Assert.Equal(8, robot.Meshes.Count);
+        }
+
+        [Fact]
+        public void InverseKinematics_Initialized()
+        {
+            Robot robot = CreateTestRobot();
+
+            Assert.NotNull(robot.InverseKinematics);
+        }
+
+        [Fact]
+        public void ForwardKinematics_Initialized()
+        {
+            Robot robot = CreateTestRobot();
+
+            Assert.NotNull(robot.ForwardKinematics);
+        }
+        #endregion
+
+        #region Duplicate
+        [Fact]
+        public void Duplicate_CreatesIndependentCopy()
+        {
+            Robot original = CreateTestRobot();
+            Robot copy = original.Duplicate();
+
+            copy.Name = "CopiedRobot";
+
+            Assert.Equal("TestRobot", original.Name);
+            Assert.Equal("CopiedRobot", copy.Name);
+        }
+
+        [Fact]
+        public void Duplicate_PreservesKinematicParameters()
+        {
+            Robot original = CreateTestRobot();
+            Robot copy = original.Duplicate();
+
+            Assert.Equal(original.RobotKinematicParameters.A1, copy.RobotKinematicParameters.A1);
+            Assert.Equal(original.RobotKinematicParameters.C4, copy.RobotKinematicParameters.C4);
+            Assert.True(copy.IsValid);
+        }
+
+        [Fact]
+        public void Duplicate_PreservesAxisLimits()
+        {
+            Robot original = CreateTestRobot();
+            Robot copy = original.Duplicate();
+
+            for (int i = 0; i < 6; i++)
+            {
+                Assert.Equal(original.InternalAxisLimits[i].T0, copy.InternalAxisLimits[i].T0);
+                Assert.Equal(original.InternalAxisLimits[i].T1, copy.InternalAxisLimits[i].T1);
+            }
+        }
+
+        [Fact]
+        public void DuplicateMechanicalUnit_ReturnsValidRobot()
+        {
+            Robot original = CreateTestRobot();
+            IMechanicalUnit copy = original.DuplicateMechanicalUnit();
+
+            Assert.Equal(6, copy.NumberOfAxes);
+        }
+        #endregion
+
+        #region ToString
+        [Fact]
+        public void ToString_ValidRobot_IncludesName()
+        {
+            Robot robot = CreateTestRobot();
+
+            Assert.Equal("Robot (TestRobot)", robot.ToString());
+        }
+
+        [Fact]
+        public void ToString_InvalidRobot_ReturnsInvalid()
+        {
+            Robot robot = new Robot();
+
+            Assert.Equal("Invalid Robot", robot.ToString());
+        }
+        #endregion
+    }
+}

--- a/RobotComponents.Tests/Definitions/RobotToolTests.cs
+++ b/RobotComponents.Tests/Definitions/RobotToolTests.cs
@@ -20,6 +20,7 @@ namespace RobotComponents.Tests.Definitions
     {
         #region Constructor
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void Constructor_Default_CreatesTool0()
         {
             RobotTool tool = new RobotTool();
@@ -32,6 +33,7 @@ namespace RobotComponents.Tests.Definitions
         }
 
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void Constructor_CustomPlanes_SetsProperties()
         {
             Plane toolPlane = new Plane(new Point3d(100, 0, 200), Vector3d.XAxis, Vector3d.YAxis);
@@ -44,6 +46,7 @@ namespace RobotComponents.Tests.Definitions
         }
 
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void Constructor_WithLoadData_SetsLoadData()
         {
             LoadData load = new LoadData("load1", 5.0,
@@ -61,6 +64,7 @@ namespace RobotComponents.Tests.Definitions
 
         #region ToRAPID
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void ToRAPID_DefaultTool0_ProducesCorrectFormat()
         {
             RobotTool tool = new RobotTool();
@@ -73,6 +77,7 @@ namespace RobotComponents.Tests.Definitions
         }
 
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void ToRAPID_CustomToolAtOriginSameOrientation_CorrectPosition()
         {
             Plane toolPlane = new Plane(new Point3d(100, 0, 200), Vector3d.XAxis, Vector3d.YAxis);
@@ -83,6 +88,7 @@ namespace RobotComponents.Tests.Definitions
         }
 
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void ToRAPID_RobotHoldFalse_StartsWithFalse()
         {
             RobotTool tool = new RobotTool();
@@ -95,6 +101,7 @@ namespace RobotComponents.Tests.Definitions
 
         #region ToRAPIDDeclaration
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void ToRAPIDDeclaration_DefaultScope_ProducesPersTooldata()
         {
             RobotTool tool = new RobotTool();
@@ -105,6 +112,7 @@ namespace RobotComponents.Tests.Definitions
         }
 
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void ToRAPIDDeclaration_LocalScope_IncludesLocalPrefix()
         {
             RobotTool tool = new RobotTool("myTool", new Mesh(), Plane.WorldXY, Plane.WorldXY);
@@ -115,6 +123,7 @@ namespace RobotComponents.Tests.Definitions
         }
 
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void ToRAPIDDeclaration_TaskScope_IncludesTaskPrefix()
         {
             RobotTool tool = new RobotTool("myTool", new Mesh(), Plane.WorldXY, Plane.WorldXY);
@@ -125,6 +134,7 @@ namespace RobotComponents.Tests.Definitions
         }
 
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void ToRAPIDDeclaration_WithRobot_Tool0ReturnsEmpty()
         {
             RobotTool tool = new RobotTool();
@@ -134,6 +144,7 @@ namespace RobotComponents.Tests.Definitions
         }
 
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void ToRAPIDDeclaration_WithRobot_CustomToolReturnsDeclaration()
         {
             RobotTool tool = new RobotTool("myTool", new Mesh(), Plane.WorldXY, Plane.WorldXY);
@@ -143,6 +154,7 @@ namespace RobotComponents.Tests.Definitions
         }
 
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void ToRAPIDDeclaration_WithRobot_EmptyNameReturnsEmpty()
         {
             RobotTool tool = new RobotTool();
@@ -155,6 +167,7 @@ namespace RobotComponents.Tests.Definitions
 
         #region IsValid
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void IsValid_DefaultTool_ReturnsTrue()
         {
             RobotTool tool = new RobotTool();
@@ -163,6 +176,7 @@ namespace RobotComponents.Tests.Definitions
         }
 
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void IsValid_EmptyName_ReturnsFalse()
         {
             RobotTool tool = new RobotTool();
@@ -172,6 +186,7 @@ namespace RobotComponents.Tests.Definitions
         }
 
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void IsValid_UnsetAttachmentPlane_ReturnsFalse()
         {
             RobotTool tool = RobotTool.GetEmptyRobotTool();
@@ -182,6 +197,7 @@ namespace RobotComponents.Tests.Definitions
 
         #region Duplicate
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void Duplicate_CreatesIndependentCopy()
         {
             RobotTool original = new RobotTool("myTool", new Mesh(), Plane.WorldXY,
@@ -195,6 +211,7 @@ namespace RobotComponents.Tests.Definitions
         }
 
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void DuplicateWithoutMesh_CreatesEmptyMeshCopy()
         {
             RobotTool original = new RobotTool("myTool", new Mesh(), Plane.WorldXY, Plane.WorldXY);
@@ -207,6 +224,7 @@ namespace RobotComponents.Tests.Definitions
 
         #region Properties
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void Datatype_AlwaysReturnsTooldata()
         {
             RobotTool tool = new RobotTool();
@@ -215,6 +233,7 @@ namespace RobotComponents.Tests.Definitions
         }
 
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void Scope_DefaultIsGlobal()
         {
             RobotTool tool = new RobotTool();
@@ -223,6 +242,7 @@ namespace RobotComponents.Tests.Definitions
         }
 
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void VariableType_DefaultIsPers()
         {
             RobotTool tool = new RobotTool();
@@ -231,6 +251,7 @@ namespace RobotComponents.Tests.Definitions
         }
 
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void ToString_ValidTool_ReturnsNameFormat()
         {
             RobotTool tool = new RobotTool();
@@ -239,6 +260,7 @@ namespace RobotComponents.Tests.Definitions
         }
 
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void ToString_InvalidTool_ReturnsInvalid()
         {
             RobotTool tool = RobotTool.GetEmptyRobotTool();
@@ -249,6 +271,7 @@ namespace RobotComponents.Tests.Definitions
 
         #region Parse
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void Parse_ValidRapidString_CreatesToolWithCorrectProperties()
         {
             string rapidData = "PERS tooldata myTool := [TRUE, [[100, 0, 200], [1, 0, 0, 0]], [5, [50, 0, 50], [1, 0, 0, 0], 0, 0, 0]];";
@@ -261,6 +284,7 @@ namespace RobotComponents.Tests.Definitions
         }
 
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void TryParse_ValidRapidString_ReturnsTrueAndTool()
         {
             string rapidData = "PERS tooldata myTool := [TRUE, [[100, 0, 200], [1, 0, 0, 0]], [5, [50, 0, 50], [1, 0, 0, 0], 0, 0, 0]];";
@@ -271,6 +295,7 @@ namespace RobotComponents.Tests.Definitions
         }
 
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void TryParse_InvalidRapidString_ReturnsFalseAndDefaultTool()
         {
             bool success = RobotTool.TryParse("invalid data", out RobotTool tool);

--- a/RobotComponents.Tests/Definitions/RobotToolTests.cs
+++ b/RobotComponents.Tests/Definitions/RobotToolTests.cs
@@ -1,0 +1,289 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This file is part of Robot Components
+// Project: https://github.com/RobotComponents/RobotComponents
+//
+// For license details, see the LICENSE file in the project root.
+
+// System Libs
+using System;
+// Rhino Libs
+using Rhino.Geometry;
+// Xunit Libs
+using Xunit;
+// Robot Components Libs
+using RobotComponents.ABB.Definitions;
+using RobotComponents.ABB.Enumerations;
+
+namespace RobotComponents.Tests.Definitions
+{
+    public class RobotToolTests
+    {
+        #region Constructor
+        [Fact]
+        public void Constructor_Default_CreatesTool0()
+        {
+            RobotTool tool = new RobotTool();
+
+            Assert.Equal("tool0", tool.Name);
+            Assert.True(tool.RobotHold);
+            Assert.Equal(Plane.WorldXY, tool.AttachmentPlane);
+            Assert.Equal(Plane.WorldXY, tool.ToolPlane);
+            Assert.True(tool.IsValid);
+        }
+
+        [Fact]
+        public void Constructor_CustomPlanes_SetsProperties()
+        {
+            Plane toolPlane = new Plane(new Point3d(100, 0, 200), Vector3d.XAxis, Vector3d.YAxis);
+            RobotTool tool = new RobotTool("myTool", new Mesh(), Plane.WorldXY, toolPlane);
+
+            Assert.Equal("myTool", tool.Name);
+            Assert.True(tool.RobotHold);
+            Assert.Equal(Plane.WorldXY, tool.AttachmentPlane);
+            Assert.True(tool.IsValid);
+        }
+
+        [Fact]
+        public void Constructor_WithLoadData_SetsLoadData()
+        {
+            LoadData load = new LoadData("load1", 5.0,
+                new Point3d(50, 0, 50),
+                new Quaternion(1, 0, 0, 0),
+                new Vector3d(0, 0, 0));
+            Plane toolPlane = new Plane(new Point3d(100, 0, 200), Vector3d.XAxis, Vector3d.YAxis);
+            RobotTool tool = new RobotTool("myTool", new Mesh(), Plane.WorldXY, toolPlane, load);
+
+            Assert.Equal("myTool", tool.Name);
+            Assert.Equal(5.0, tool.LoadData.Mass);
+            Assert.True(tool.IsValid);
+        }
+        #endregion
+
+        #region ToRAPID
+        [Fact]
+        public void ToRAPID_DefaultTool0_ProducesCorrectFormat()
+        {
+            RobotTool tool = new RobotTool();
+            string rapid = tool.ToRAPID();
+
+            // tool0: WorldXY attachment and tool planes → position (0,0,0), identity quaternion
+            Assert.StartsWith("[TRUE, [[0, 0, 0], [1, 0, 0, 0]], ", rapid);
+            Assert.EndsWith("]]", rapid);
+            Assert.Contains("[0.001, [0, 0, 0.001], [1, 0, 0, 0], 0, 0, 0]", rapid);
+        }
+
+        [Fact]
+        public void ToRAPID_CustomToolAtOriginSameOrientation_CorrectPosition()
+        {
+            Plane toolPlane = new Plane(new Point3d(100, 0, 200), Vector3d.XAxis, Vector3d.YAxis);
+            RobotTool tool = new RobotTool("myTool", new Mesh(), Plane.WorldXY, toolPlane);
+            string rapid = tool.ToRAPID();
+
+            Assert.StartsWith("[TRUE, [[100, 0, 200], [1, 0, 0, 0]], ", rapid);
+        }
+
+        [Fact]
+        public void ToRAPID_RobotHoldFalse_StartsWithFalse()
+        {
+            RobotTool tool = new RobotTool();
+            tool.RobotHold = false;
+            string rapid = tool.ToRAPID();
+
+            Assert.StartsWith("[FALSE, ", rapid);
+        }
+        #endregion
+
+        #region ToRAPIDDeclaration
+        [Fact]
+        public void ToRAPIDDeclaration_DefaultScope_ProducesPersTooldata()
+        {
+            RobotTool tool = new RobotTool();
+            string decl = tool.ToRAPIDDeclaration();
+
+            Assert.StartsWith("PERS tooldata tool0 := ", decl);
+            Assert.EndsWith(";", decl);
+        }
+
+        [Fact]
+        public void ToRAPIDDeclaration_LocalScope_IncludesLocalPrefix()
+        {
+            RobotTool tool = new RobotTool("myTool", new Mesh(), Plane.WorldXY, Plane.WorldXY);
+            tool.Scope = Scope.LOCAL;
+            string decl = tool.ToRAPIDDeclaration();
+
+            Assert.StartsWith("LOCAL PERS tooldata myTool := ", decl);
+        }
+
+        [Fact]
+        public void ToRAPIDDeclaration_TaskScope_IncludesTaskPrefix()
+        {
+            RobotTool tool = new RobotTool("myTool", new Mesh(), Plane.WorldXY, Plane.WorldXY);
+            tool.Scope = Scope.TASK;
+            string decl = tool.ToRAPIDDeclaration();
+
+            Assert.StartsWith("TASK PERS tooldata myTool := ", decl);
+        }
+
+        [Fact]
+        public void ToRAPIDDeclaration_WithRobot_Tool0ReturnsEmpty()
+        {
+            RobotTool tool = new RobotTool();
+            string decl = tool.ToRAPIDDeclaration(null);
+
+            Assert.Equal(string.Empty, decl);
+        }
+
+        [Fact]
+        public void ToRAPIDDeclaration_WithRobot_CustomToolReturnsDeclaration()
+        {
+            RobotTool tool = new RobotTool("myTool", new Mesh(), Plane.WorldXY, Plane.WorldXY);
+            string decl = tool.ToRAPIDDeclaration(null);
+
+            Assert.StartsWith("PERS tooldata myTool := ", decl);
+        }
+
+        [Fact]
+        public void ToRAPIDDeclaration_WithRobot_EmptyNameReturnsEmpty()
+        {
+            RobotTool tool = new RobotTool();
+            tool.Name = "";
+            string decl = tool.ToRAPIDDeclaration(null);
+
+            Assert.Equal(string.Empty, decl);
+        }
+        #endregion
+
+        #region IsValid
+        [Fact]
+        public void IsValid_DefaultTool_ReturnsTrue()
+        {
+            RobotTool tool = new RobotTool();
+
+            Assert.True(tool.IsValid);
+        }
+
+        [Fact]
+        public void IsValid_EmptyName_ReturnsFalse()
+        {
+            RobotTool tool = new RobotTool();
+            tool.Name = "";
+
+            Assert.False(tool.IsValid);
+        }
+
+        [Fact]
+        public void IsValid_UnsetAttachmentPlane_ReturnsFalse()
+        {
+            RobotTool tool = RobotTool.GetEmptyRobotTool();
+
+            Assert.False(tool.IsValid);
+        }
+        #endregion
+
+        #region Duplicate
+        [Fact]
+        public void Duplicate_CreatesIndependentCopy()
+        {
+            RobotTool original = new RobotTool("myTool", new Mesh(), Plane.WorldXY,
+                new Plane(new Point3d(100, 0, 200), Vector3d.XAxis, Vector3d.YAxis));
+
+            RobotTool copy = original.Duplicate();
+            copy.Name = "changed";
+
+            Assert.Equal("myTool", original.Name);
+            Assert.Equal("changed", copy.Name);
+        }
+
+        [Fact]
+        public void DuplicateWithoutMesh_CreatesEmptyMeshCopy()
+        {
+            RobotTool original = new RobotTool("myTool", new Mesh(), Plane.WorldXY, Plane.WorldXY);
+            RobotTool copy = original.DuplicateWithoutMesh();
+
+            Assert.Equal("myTool", copy.Name);
+            Assert.True(copy.IsValid);
+        }
+        #endregion
+
+        #region Properties
+        [Fact]
+        public void Datatype_AlwaysReturnsTooldata()
+        {
+            RobotTool tool = new RobotTool();
+
+            Assert.Equal("tooldata", tool.Datatype);
+        }
+
+        [Fact]
+        public void Scope_DefaultIsGlobal()
+        {
+            RobotTool tool = new RobotTool();
+
+            Assert.Equal(Scope.GLOBAL, tool.Scope);
+        }
+
+        [Fact]
+        public void VariableType_DefaultIsPers()
+        {
+            RobotTool tool = new RobotTool();
+
+            Assert.Equal(VariableType.PERS, tool.VariableType);
+        }
+
+        [Fact]
+        public void ToString_ValidTool_ReturnsNameFormat()
+        {
+            RobotTool tool = new RobotTool();
+
+            Assert.Equal("Robot Tool (tool0)", tool.ToString());
+        }
+
+        [Fact]
+        public void ToString_InvalidTool_ReturnsInvalid()
+        {
+            RobotTool tool = RobotTool.GetEmptyRobotTool();
+
+            Assert.Equal("Invalid Robot Tool", tool.ToString());
+        }
+        #endregion
+
+        #region Parse
+        [Fact]
+        public void Parse_ValidRapidString_CreatesToolWithCorrectProperties()
+        {
+            string rapidData = "PERS tooldata myTool := [TRUE, [[100, 0, 200], [1, 0, 0, 0]], [5, [50, 0, 50], [1, 0, 0, 0], 0, 0, 0]];";
+            RobotTool tool = RobotTool.Parse(rapidData);
+
+            Assert.Equal("myTool", tool.Name);
+            Assert.True(tool.RobotHold);
+            Assert.Equal(5.0, tool.LoadData.Mass);
+            Assert.True(tool.IsValid);
+        }
+
+        [Fact]
+        public void TryParse_ValidRapidString_ReturnsTrueAndTool()
+        {
+            string rapidData = "PERS tooldata myTool := [TRUE, [[100, 0, 200], [1, 0, 0, 0]], [5, [50, 0, 50], [1, 0, 0, 0], 0, 0, 0]];";
+            bool success = RobotTool.TryParse(rapidData, out RobotTool tool);
+
+            Assert.True(success);
+            Assert.Equal("myTool", tool.Name);
+        }
+
+        [Fact]
+        public void TryParse_InvalidRapidString_ReturnsFalseAndDefaultTool()
+        {
+            bool success = RobotTool.TryParse("invalid data", out RobotTool tool);
+
+            Assert.False(success);
+            Assert.Equal("tool0", tool.Name);
+        }
+
+        [Fact]
+        public void Parse_InvalidRapidString_ThrowsException()
+        {
+            Assert.Throws<InvalidCastException>(() => RobotTool.Parse("PERS tooldata t := [TRUE, [0, 0]];"));
+        }
+        #endregion
+    }
+}

--- a/RobotComponents.Tests/Definitions/RobotToolTests.cs
+++ b/RobotComponents.Tests/Definitions/RobotToolTests.cs
@@ -304,6 +304,7 @@ namespace RobotComponents.Tests.Definitions
             Assert.Equal("tool0", tool.Name);
         }
 
+        // No RequiresRhino: Parse throws before reaching any Rhino native call
         [Fact]
         public void Parse_InvalidRapidString_ThrowsException()
         {

--- a/RobotComponents.Tests/Definitions/WorkObjectTests.cs
+++ b/RobotComponents.Tests/Definitions/WorkObjectTests.cs
@@ -1,0 +1,325 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This file is part of Robot Components
+// Project: https://github.com/RobotComponents/RobotComponents
+//
+// For license details, see the LICENSE file in the project root.
+
+// System Libs
+using System;
+// Rhino Libs
+using Rhino.Geometry;
+// Xunit Libs
+using Xunit;
+// Robot Components Libs
+using RobotComponents.ABB.Definitions;
+using RobotComponents.ABB.Enumerations;
+
+namespace RobotComponents.Tests.Definitions
+{
+    public class WorkObjectTests
+    {
+        #region Constructor
+        [Fact]
+        public void Constructor_Default_CreatesWobj0()
+        {
+            WorkObject wobj = new WorkObject();
+
+            Assert.Equal("wobj0", wobj.Name);
+            Assert.False(wobj.RobotHold);
+            Assert.True(wobj.FixedFrame);
+            Assert.Equal(Plane.WorldXY, wobj.ObjectFrame);
+            Assert.Equal(Plane.WorldXY, wobj.UserFrame);
+            Assert.Null(wobj.ExternalAxis);
+            Assert.True(wobj.IsValid);
+        }
+
+        [Fact]
+        public void Constructor_NameAndObjectFrame_SetsPropertiesCorrectly()
+        {
+            Plane objectFrame = new Plane(new Point3d(500, 200, 100), Vector3d.XAxis, Vector3d.YAxis);
+            WorkObject wobj = new WorkObject("myWobj", objectFrame);
+
+            Assert.Equal("myWobj", wobj.Name);
+            Assert.Equal(Plane.WorldXY, wobj.UserFrame);
+            Assert.True(wobj.FixedFrame);
+            Assert.True(wobj.IsValid);
+        }
+
+        [Fact]
+        public void Constructor_WithUserFrame_SetsUserFrameCorrectly()
+        {
+            Plane userFrame = new Plane(new Point3d(100, 0, 0), Vector3d.XAxis, Vector3d.YAxis);
+            Plane objectFrame = new Plane(new Point3d(500, 200, 100), Vector3d.XAxis, Vector3d.YAxis);
+            WorkObject wobj = new WorkObject("myWobj", userFrame, objectFrame);
+
+            Assert.Equal("myWobj", wobj.Name);
+            Assert.Equal(userFrame, wobj.UserFrame);
+            Assert.True(wobj.FixedFrame);
+            Assert.True(wobj.IsValid);
+        }
+        #endregion
+
+        #region ToRAPID
+        [Fact]
+        public void ToRAPID_DefaultWobj0_ProducesCorrectFormat()
+        {
+            WorkObject wobj = new WorkObject();
+            string rapid = wobj.ToRAPID();
+
+            // wobj0: WorldXY frames, fixed, no external axis, not robot hold
+            Assert.StartsWith("[FALSE, TRUE, \"\", ", rapid);
+            Assert.Contains("[[0, 0, 0], [1, 0, 0, 0]]", rapid);
+        }
+
+        [Fact]
+        public void ToRAPID_CustomObjectFrame_IncludesTranslation()
+        {
+            Plane objectFrame = new Plane(new Point3d(500, 200, 100), Vector3d.XAxis, Vector3d.YAxis);
+            WorkObject wobj = new WorkObject("myWobj", objectFrame);
+            string rapid = wobj.ToRAPID();
+
+            // Object frame should contain the translated origin
+            Assert.Contains("[[500, 200, 100], [1, 0, 0, 0]]", rapid);
+            // User frame at origin
+            Assert.Contains("[FALSE, TRUE, \"\", [[0, 0, 0], [1, 0, 0, 0]]", rapid);
+        }
+
+        [Fact]
+        public void ToRAPID_WithUserFrame_IncludesUserFrameData()
+        {
+            Plane userFrame = new Plane(new Point3d(100, 50, 0), Vector3d.XAxis, Vector3d.YAxis);
+            Plane objectFrame = new Plane(new Point3d(500, 200, 100), Vector3d.XAxis, Vector3d.YAxis);
+            WorkObject wobj = new WorkObject("myWobj", userFrame, objectFrame);
+            string rapid = wobj.ToRAPID();
+
+            Assert.Contains("[[100, 50, 0], [1, 0, 0, 0]]", rapid);
+        }
+        #endregion
+
+        #region ToRAPIDDeclaration
+        [Fact]
+        public void ToRAPIDDeclaration_DefaultScope_ProducesPersWobjdata()
+        {
+            WorkObject wobj = new WorkObject();
+            string decl = wobj.ToRAPIDDeclaration();
+
+            Assert.StartsWith("PERS wobjdata wobj0 := ", decl);
+            Assert.EndsWith(";", decl);
+        }
+
+        [Fact]
+        public void ToRAPIDDeclaration_LocalScope_IncludesLocalPrefix()
+        {
+            WorkObject wobj = new WorkObject("myWobj", Plane.WorldXY);
+            wobj.Scope = Scope.LOCAL;
+            string decl = wobj.ToRAPIDDeclaration();
+
+            Assert.StartsWith("LOCAL PERS wobjdata myWobj := ", decl);
+        }
+
+        [Fact]
+        public void ToRAPIDDeclaration_WithRobot_Wobj0ReturnsEmpty()
+        {
+            WorkObject wobj = new WorkObject();
+            string decl = wobj.ToRAPIDDeclaration(null);
+
+            Assert.Equal(string.Empty, decl);
+        }
+
+        [Fact]
+        public void ToRAPIDDeclaration_WithRobot_CustomWobjReturnsDeclaration()
+        {
+            WorkObject wobj = new WorkObject("myWobj", Plane.WorldXY);
+            string decl = wobj.ToRAPIDDeclaration(null);
+
+            Assert.StartsWith("PERS wobjdata myWobj := ", decl);
+        }
+
+        [Fact]
+        public void ToRAPIDDeclaration_WithRobot_EmptyNameReturnsEmpty()
+        {
+            WorkObject wobj = new WorkObject();
+            wobj.Name = "";
+            string decl = wobj.ToRAPIDDeclaration(null);
+
+            Assert.Equal(string.Empty, decl);
+        }
+        #endregion
+
+        #region IsValid
+        [Fact]
+        public void IsValid_DefaultWobj_ReturnsTrue()
+        {
+            WorkObject wobj = new WorkObject();
+
+            Assert.True(wobj.IsValid);
+        }
+
+        [Fact]
+        public void IsValid_EmptyName_ReturnsFalse()
+        {
+            WorkObject wobj = new WorkObject();
+            wobj.Name = "";
+
+            Assert.False(wobj.IsValid);
+        }
+
+        [Fact]
+        public void IsValid_NullName_ReturnsFalse()
+        {
+            WorkObject wobj = new WorkObject();
+            wobj.Name = null;
+
+            Assert.False(wobj.IsValid);
+        }
+        #endregion
+
+        #region FixedFrame
+        [Fact]
+        public void FixedFrame_NoExternalAxis_ReturnsTrue()
+        {
+            WorkObject wobj = new WorkObject("myWobj", Plane.WorldXY);
+
+            Assert.True(wobj.FixedFrame);
+        }
+        #endregion
+
+        #region GlobalWorkObjectPlane
+        [Fact]
+        public void GlobalWorkObjectPlane_DefaultWobj_EqualsWorldXY()
+        {
+            WorkObject wobj = new WorkObject();
+
+            Assert.Equal(Plane.WorldXY.Origin, wobj.GlobalWorkObjectPlane.Origin);
+        }
+
+        [Fact]
+        public void GlobalWorkObjectPlane_WithUserFrame_CombinesFrames()
+        {
+            Plane userFrame = new Plane(new Point3d(100, 0, 0), Vector3d.XAxis, Vector3d.YAxis);
+            Plane objectFrame = new Plane(new Point3d(50, 0, 0), Vector3d.XAxis, Vector3d.YAxis);
+            WorkObject wobj = new WorkObject("myWobj", userFrame, objectFrame);
+
+            // Global plane = objectFrame re-oriented by userFrame
+            // objectFrame (50,0,0) placed in userFrame (100,0,0) → global (150,0,0)
+            double tolerance = 1e-6;
+            Assert.InRange(wobj.GlobalWorkObjectPlane.Origin.X, 150 - tolerance, 150 + tolerance);
+            Assert.InRange(wobj.GlobalWorkObjectPlane.Origin.Y, -tolerance, tolerance);
+            Assert.InRange(wobj.GlobalWorkObjectPlane.Origin.Z, -tolerance, tolerance);
+        }
+        #endregion
+
+        #region Duplicate
+        [Fact]
+        public void Duplicate_CreatesIndependentCopy()
+        {
+            WorkObject original = new WorkObject("myWobj",
+                new Plane(new Point3d(500, 200, 100), Vector3d.XAxis, Vector3d.YAxis));
+
+            WorkObject copy = original.Duplicate();
+            copy.Name = "changed";
+
+            Assert.Equal("myWobj", original.Name);
+            Assert.Equal("changed", copy.Name);
+        }
+
+        [Fact]
+        public void Duplicate_PreservesAllProperties()
+        {
+            Plane userFrame = new Plane(new Point3d(100, 0, 0), Vector3d.XAxis, Vector3d.YAxis);
+            Plane objectFrame = new Plane(new Point3d(500, 200, 100), Vector3d.XAxis, Vector3d.YAxis);
+            WorkObject original = new WorkObject("myWobj", userFrame, objectFrame);
+            original.Scope = Scope.LOCAL;
+
+            WorkObject copy = original.Duplicate();
+
+            Assert.Equal("myWobj", copy.Name);
+            Assert.Equal(Scope.LOCAL, copy.Scope);
+            Assert.Equal(original.ObjectFrame, copy.ObjectFrame);
+            Assert.Equal(original.UserFrame, copy.UserFrame);
+            Assert.True(copy.FixedFrame);
+        }
+        #endregion
+
+        #region Properties
+        [Fact]
+        public void Datatype_AlwaysReturnsWobjdata()
+        {
+            WorkObject wobj = new WorkObject();
+
+            Assert.Equal("wobjdata", wobj.Datatype);
+        }
+
+        [Fact]
+        public void Scope_DefaultIsGlobal()
+        {
+            WorkObject wobj = new WorkObject();
+
+            Assert.Equal(Scope.GLOBAL, wobj.Scope);
+        }
+
+        [Fact]
+        public void VariableType_DefaultIsPers()
+        {
+            WorkObject wobj = new WorkObject();
+
+            Assert.Equal(VariableType.PERS, wobj.VariableType);
+        }
+
+        [Fact]
+        public void ToString_ValidWobj_ReturnsNameFormat()
+        {
+            WorkObject wobj = new WorkObject();
+
+            Assert.Equal("Work Object (wobj0)", wobj.ToString());
+        }
+
+        [Fact]
+        public void ToString_InvalidWobj_ReturnsInvalid()
+        {
+            WorkObject wobj = new WorkObject();
+            wobj.Name = "";
+
+            Assert.Equal("Invalid Work Object", wobj.ToString());
+        }
+        #endregion
+
+        #region Parse
+        [Fact]
+        public void Parse_ValidRapidString_CreatesWobjWithCorrectProperties()
+        {
+            string rapidData = "PERS wobjdata myWobj := [FALSE, TRUE, \"\", [[0, 0, 0], [1, 0, 0, 0]], [[500, 200, 100], [1, 0, 0, 0]]];";
+            WorkObject wobj = WorkObject.Parse(rapidData);
+
+            Assert.Equal("myWobj", wobj.Name);
+            Assert.False(wobj.RobotHold);
+            Assert.True(wobj.IsValid);
+        }
+
+        [Fact]
+        public void TryParse_ValidRapidString_ReturnsTrueAndWobj()
+        {
+            string rapidData = "PERS wobjdata myWobj := [FALSE, TRUE, \"\", [[0, 0, 0], [1, 0, 0, 0]], [[500, 200, 100], [1, 0, 0, 0]]];";
+            bool success = WorkObject.TryParse(rapidData, out WorkObject wobj);
+
+            Assert.True(success);
+            Assert.Equal("myWobj", wobj.Name);
+        }
+
+        [Fact]
+        public void TryParse_InvalidRapidString_ReturnsFalseAndDefaultWobj()
+        {
+            bool success = WorkObject.TryParse("invalid data", out WorkObject wobj);
+
+            Assert.False(success);
+            Assert.Equal("wobj0", wobj.Name);
+        }
+
+        [Fact]
+        public void Parse_InvalidRapidString_ThrowsException()
+        {
+            Assert.Throws<InvalidCastException>(() => WorkObject.Parse("PERS wobjdata w := [FALSE, TRUE]];"));
+        }
+        #endregion
+    }
+}

--- a/RobotComponents.Tests/Definitions/WorkObjectTests.cs
+++ b/RobotComponents.Tests/Definitions/WorkObjectTests.cs
@@ -20,6 +20,7 @@ namespace RobotComponents.Tests.Definitions
     {
         #region Constructor
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void Constructor_Default_CreatesWobj0()
         {
             WorkObject wobj = new WorkObject();
@@ -34,6 +35,7 @@ namespace RobotComponents.Tests.Definitions
         }
 
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void Constructor_NameAndObjectFrame_SetsPropertiesCorrectly()
         {
             Plane objectFrame = new Plane(new Point3d(500, 200, 100), Vector3d.XAxis, Vector3d.YAxis);
@@ -46,6 +48,7 @@ namespace RobotComponents.Tests.Definitions
         }
 
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void Constructor_WithUserFrame_SetsUserFrameCorrectly()
         {
             Plane userFrame = new Plane(new Point3d(100, 0, 0), Vector3d.XAxis, Vector3d.YAxis);
@@ -61,6 +64,7 @@ namespace RobotComponents.Tests.Definitions
 
         #region ToRAPID
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void ToRAPID_DefaultWobj0_ProducesCorrectFormat()
         {
             WorkObject wobj = new WorkObject();
@@ -72,6 +76,7 @@ namespace RobotComponents.Tests.Definitions
         }
 
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void ToRAPID_CustomObjectFrame_IncludesTranslation()
         {
             Plane objectFrame = new Plane(new Point3d(500, 200, 100), Vector3d.XAxis, Vector3d.YAxis);
@@ -85,6 +90,7 @@ namespace RobotComponents.Tests.Definitions
         }
 
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void ToRAPID_WithUserFrame_IncludesUserFrameData()
         {
             Plane userFrame = new Plane(new Point3d(100, 50, 0), Vector3d.XAxis, Vector3d.YAxis);
@@ -98,6 +104,7 @@ namespace RobotComponents.Tests.Definitions
 
         #region ToRAPIDDeclaration
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void ToRAPIDDeclaration_DefaultScope_ProducesPersWobjdata()
         {
             WorkObject wobj = new WorkObject();
@@ -108,6 +115,7 @@ namespace RobotComponents.Tests.Definitions
         }
 
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void ToRAPIDDeclaration_LocalScope_IncludesLocalPrefix()
         {
             WorkObject wobj = new WorkObject("myWobj", Plane.WorldXY);
@@ -118,6 +126,7 @@ namespace RobotComponents.Tests.Definitions
         }
 
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void ToRAPIDDeclaration_WithRobot_Wobj0ReturnsEmpty()
         {
             WorkObject wobj = new WorkObject();
@@ -127,6 +136,7 @@ namespace RobotComponents.Tests.Definitions
         }
 
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void ToRAPIDDeclaration_WithRobot_CustomWobjReturnsDeclaration()
         {
             WorkObject wobj = new WorkObject("myWobj", Plane.WorldXY);
@@ -136,6 +146,7 @@ namespace RobotComponents.Tests.Definitions
         }
 
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void ToRAPIDDeclaration_WithRobot_EmptyNameReturnsEmpty()
         {
             WorkObject wobj = new WorkObject();
@@ -148,6 +159,7 @@ namespace RobotComponents.Tests.Definitions
 
         #region IsValid
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void IsValid_DefaultWobj_ReturnsTrue()
         {
             WorkObject wobj = new WorkObject();
@@ -156,6 +168,7 @@ namespace RobotComponents.Tests.Definitions
         }
 
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void IsValid_EmptyName_ReturnsFalse()
         {
             WorkObject wobj = new WorkObject();
@@ -165,6 +178,7 @@ namespace RobotComponents.Tests.Definitions
         }
 
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void IsValid_NullName_ReturnsFalse()
         {
             WorkObject wobj = new WorkObject();
@@ -176,6 +190,7 @@ namespace RobotComponents.Tests.Definitions
 
         #region FixedFrame
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void FixedFrame_NoExternalAxis_ReturnsTrue()
         {
             WorkObject wobj = new WorkObject("myWobj", Plane.WorldXY);
@@ -186,6 +201,7 @@ namespace RobotComponents.Tests.Definitions
 
         #region GlobalWorkObjectPlane
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void GlobalWorkObjectPlane_DefaultWobj_EqualsWorldXY()
         {
             WorkObject wobj = new WorkObject();
@@ -194,6 +210,7 @@ namespace RobotComponents.Tests.Definitions
         }
 
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void GlobalWorkObjectPlane_WithUserFrame_CombinesFrames()
         {
             Plane userFrame = new Plane(new Point3d(100, 0, 0), Vector3d.XAxis, Vector3d.YAxis);
@@ -211,6 +228,7 @@ namespace RobotComponents.Tests.Definitions
 
         #region Duplicate
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void Duplicate_CreatesIndependentCopy()
         {
             WorkObject original = new WorkObject("myWobj",
@@ -224,6 +242,7 @@ namespace RobotComponents.Tests.Definitions
         }
 
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void Duplicate_PreservesAllProperties()
         {
             Plane userFrame = new Plane(new Point3d(100, 0, 0), Vector3d.XAxis, Vector3d.YAxis);
@@ -243,6 +262,7 @@ namespace RobotComponents.Tests.Definitions
 
         #region Properties
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void Datatype_AlwaysReturnsWobjdata()
         {
             WorkObject wobj = new WorkObject();
@@ -251,6 +271,7 @@ namespace RobotComponents.Tests.Definitions
         }
 
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void Scope_DefaultIsGlobal()
         {
             WorkObject wobj = new WorkObject();
@@ -259,6 +280,7 @@ namespace RobotComponents.Tests.Definitions
         }
 
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void VariableType_DefaultIsPers()
         {
             WorkObject wobj = new WorkObject();
@@ -267,6 +289,7 @@ namespace RobotComponents.Tests.Definitions
         }
 
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void ToString_ValidWobj_ReturnsNameFormat()
         {
             WorkObject wobj = new WorkObject();
@@ -275,6 +298,7 @@ namespace RobotComponents.Tests.Definitions
         }
 
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void ToString_InvalidWobj_ReturnsInvalid()
         {
             WorkObject wobj = new WorkObject();
@@ -286,6 +310,7 @@ namespace RobotComponents.Tests.Definitions
 
         #region Parse
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void Parse_ValidRapidString_CreatesWobjWithCorrectProperties()
         {
             string rapidData = "PERS wobjdata myWobj := [FALSE, TRUE, \"\", [[0, 0, 0], [1, 0, 0, 0]], [[500, 200, 100], [1, 0, 0, 0]]];";
@@ -297,6 +322,7 @@ namespace RobotComponents.Tests.Definitions
         }
 
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void TryParse_ValidRapidString_ReturnsTrueAndWobj()
         {
             string rapidData = "PERS wobjdata myWobj := [FALSE, TRUE, \"\", [[0, 0, 0], [1, 0, 0, 0]], [[500, 200, 100], [1, 0, 0, 0]]];";
@@ -307,6 +333,7 @@ namespace RobotComponents.Tests.Definitions
         }
 
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void TryParse_InvalidRapidString_ReturnsFalseAndDefaultWobj()
         {
             bool success = WorkObject.TryParse("invalid data", out WorkObject wobj);

--- a/RobotComponents.Tests/Definitions/WorkObjectTests.cs
+++ b/RobotComponents.Tests/Definitions/WorkObjectTests.cs
@@ -18,6 +18,8 @@ namespace RobotComponents.Tests.Definitions
 {
     public class WorkObjectTests
     {
+        private const double Tolerance = 1e-6;
+
         #region Constructor
         [Fact]
         [Trait("Category", "RequiresRhino")]
@@ -219,10 +221,9 @@ namespace RobotComponents.Tests.Definitions
 
             // Global plane = objectFrame re-oriented by userFrame
             // objectFrame (50,0,0) placed in userFrame (100,0,0) → global (150,0,0)
-            double tolerance = 1e-6;
-            Assert.InRange(wobj.GlobalWorkObjectPlane.Origin.X, 150 - tolerance, 150 + tolerance);
-            Assert.InRange(wobj.GlobalWorkObjectPlane.Origin.Y, -tolerance, tolerance);
-            Assert.InRange(wobj.GlobalWorkObjectPlane.Origin.Z, -tolerance, tolerance);
+            Assert.InRange(wobj.GlobalWorkObjectPlane.Origin.X, 150 - Tolerance, 150 + Tolerance);
+            Assert.InRange(wobj.GlobalWorkObjectPlane.Origin.Y, -Tolerance, Tolerance);
+            Assert.InRange(wobj.GlobalWorkObjectPlane.Origin.Z, -Tolerance, Tolerance);
         }
         #endregion
 
@@ -342,6 +343,7 @@ namespace RobotComponents.Tests.Definitions
             Assert.Equal("wobj0", wobj.Name);
         }
 
+        // No RequiresRhino: Parse throws before reaching any Rhino native call
         [Fact]
         public void Parse_InvalidRapidString_ThrowsException()
         {

--- a/RobotComponents.Tests/Kinematics/KinematicsTests.cs
+++ b/RobotComponents.Tests/Kinematics/KinematicsTests.cs
@@ -1,0 +1,489 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This file is part of Robot Components
+// Project: https://github.com/RobotComponents/RobotComponents
+//
+// For license details, see the LICENSE file in the project root.
+
+// System Libs
+using System;
+using System.Collections.Generic;
+using System.Linq;
+// Rhino Libs
+using Rhino.Geometry;
+// Xunit Libs
+using Xunit;
+// Robot Components Libs
+using RobotComponents.Generic.Kinematics;
+using RobotComponents.ABB.Kinematics;
+using RobotComponents.ABB.Definitions;
+using RobotComponents.ABB.Actions.Declarations;
+
+namespace RobotComponents.Tests.Kinematics
+{
+    public class KinematicsTests
+    {
+        private const double Tolerance = 1e-3;
+        private const double AngleTolerance = 1e-6;
+
+        /// <summary>
+        /// Creates an OPW solver configured with IRB120-3/0.58 kinematic parameters.
+        /// </summary>
+        private static OPWKinematics CreateIRB120OPW()
+        {
+            OPWKinematics opw = new OPWKinematics();
+            opw.A1 = 0;
+            opw.B = 0;
+            opw.C1 = 290;
+            opw.C2 = 270;
+            opw.C4 = 72;
+            opw.A2 = -70;   // triggers UpdateRobotParameters
+            opw.C3 = 302;   // triggers UpdateRobotParameters with correct A2
+            opw.Offsets = new double[] { 0, 0, -Math.PI / 2, 0, 0, 0 };
+            opw.Signs = new int[] { 1, 1, 1, 1, 1, 1 };
+            return opw;
+        }
+
+        /// <summary>
+        /// Creates a test robot with IRB120-3/0.58 kinematic parameters and empty meshes.
+        /// </summary>
+        private static Robot CreateTestRobot()
+        {
+            List<Mesh> meshes = Enumerable.Range(0, 7).Select(_ => new Mesh()).ToList();
+            RobotKinematicParameters parameters = new RobotKinematicParameters(0, -70, 0, 0, 290, 270, 302, 72);
+            Interval[] limits = new Interval[]
+            {
+                new Interval(-165, 165),
+                new Interval(-110, 110),
+                new Interval(-110, 70),
+                new Interval(-160, 160),
+                new Interval(-120, 120),
+                new Interval(-400, 400)
+            };
+            return new Robot("TestRobot", meshes, parameters, limits, Plane.WorldXY, new RobotTool());
+        }
+
+        #region OPW Forward Kinematics
+        [Fact]
+        public void OPWForward_AllZeroInternalAngles_ReturnsValidPlane()
+        {
+            OPWKinematics opw = CreateIRB120OPW();
+
+            // Input [0, 0, -pi/2, 0, 0, 0] → internal angles all 0 (offset on joint 3)
+            double[] pose = { 0, 0, -Math.PI / 2, 0, 0, 0 };
+            Plane result = opw.Forward(pose);
+
+            Assert.False(double.IsNaN(result.Origin.X));
+            Assert.False(double.IsNaN(result.Origin.Y));
+            Assert.False(double.IsNaN(result.Origin.Z));
+        }
+
+        [Fact]
+        public void OPWForward_AllZeroInternalAngles_CorrectPosition()
+        {
+            OPWKinematics opw = CreateIRB120OPW();
+
+            // With all internal angles at 0, expected end plane:
+            // wrist at (A2, 0, C1+C2+C3_contribution) → approximately (-70, 0, 862)
+            // end plane at (-70 + C4*zComponent, 0, 862 + C4*zComponent)
+            // With identity orientation: end = (-70, 0, 862+72) = (-70, 0, 934)
+            double[] pose = { 0, 0, -Math.PI / 2, 0, 0, 0 };
+            Plane result = opw.Forward(pose);
+
+            Assert.InRange(result.Origin.X, -70 - Tolerance, -70 + Tolerance);
+            Assert.InRange(result.Origin.Y, -Tolerance, Tolerance);
+            Assert.InRange(result.Origin.Z, 934 - Tolerance, 934 + Tolerance);
+        }
+
+        [Fact]
+        public void OPWForward_AllZeroInternalAngles_OutputsWristPosition()
+        {
+            OPWKinematics opw = CreateIRB120OPW();
+
+            double[] pose = { 0, 0, -Math.PI / 2, 0, 0, 0 };
+            opw.Forward(pose, out Point3d wristPosition);
+
+            // Wrist position should be at (-70, 0, 862)
+            Assert.InRange(wristPosition.X, -70 - Tolerance, -70 + Tolerance);
+            Assert.InRange(wristPosition.Y, -Tolerance, Tolerance);
+            Assert.InRange(wristPosition.Z, 862 - Tolerance, 862 + Tolerance);
+        }
+
+        [Fact]
+        public void OPWForward_Joint1Rotated_RotatesXYPosition()
+        {
+            OPWKinematics opw = CreateIRB120OPW();
+
+            // Rotate joint 1 by pi/2 (90 degrees)
+            double[] pose = { Math.PI / 2, 0, -Math.PI / 2, 0, 0, 0 };
+            Plane result = opw.Forward(pose);
+
+            // With joint 1 at 90°, X/Y should swap: (-70, 0) → (0, -70)
+            Assert.InRange(result.Origin.X, -Tolerance, Tolerance);
+            Assert.InRange(result.Origin.Y, -70 - Tolerance, -70 + Tolerance);
+            Assert.InRange(result.Origin.Z, 934 - Tolerance, 934 + Tolerance);
+        }
+
+        [Fact]
+        public void OPWForward_DifferentJointAngles_ProducesDifferentPosition()
+        {
+            OPWKinematics opw = CreateIRB120OPW();
+
+            double[] pose1 = { 0, 0, -Math.PI / 2, 0, 0, 0 };
+            double[] pose2 = { 0.5, 0.3, -Math.PI / 2 + 0.2, 0, Math.PI / 6, 0 };
+
+            Plane result1 = opw.Forward(pose1);
+            Plane result2 = opw.Forward(pose2);
+
+            // Different joints should produce different positions
+            double distance = result1.Origin.DistanceTo(result2.Origin);
+            Assert.True(distance > 1.0, "Different joint angles should produce different TCP positions");
+        }
+
+        [Fact]
+        public void OPWForward_TooFewJoints_ThrowsException()
+        {
+            OPWKinematics opw = CreateIRB120OPW();
+
+            double[] pose = { 0, 0, 0 }; // Only 3 values
+            Assert.Throws<Exception>(() => opw.Forward(pose));
+        }
+        #endregion
+
+        #region OPW Inverse Kinematics
+        [Fact]
+        public void OPWInverse_ValidPlane_Produces8Solutions()
+        {
+            OPWKinematics opw = CreateIRB120OPW();
+
+            Plane endPlane = new Plane(
+                new Point3d(-70, 0, 934),
+                new Vector3d(1, 0, 0),
+                new Vector3d(0, 1, 0));
+
+            opw.Inverse(endPlane);
+
+            // Should always produce 8 solution arrays
+            Assert.Equal(8, opw.Solutions.Length);
+            Assert.Equal(6, opw.Solutions[0].Length);
+        }
+
+        [Fact]
+        public void OPWInverse_SingularityFlags_HaveCorrectLength()
+        {
+            OPWKinematics opw = CreateIRB120OPW();
+
+            Plane endPlane = new Plane(
+                new Point3d(-70, 0, 934),
+                new Vector3d(1, 0, 0),
+                new Vector3d(0, 1, 0));
+
+            opw.Inverse(endPlane);
+
+            Assert.Equal(8, opw.IsShoulderSingularity.Length);
+            Assert.Equal(8, opw.IsElbowSingularity.Length);
+            Assert.Equal(8, opw.IsWristSingularity.Length);
+        }
+        #endregion
+
+        #region OPW Forward-Inverse Round-trip
+        [Fact]
+        public void OPWRoundTrip_AllZeroInternalAngles_RecoversSolution()
+        {
+            OPWKinematics opw = CreateIRB120OPW();
+
+            double[] inputPose = { 0, 0, -Math.PI / 2, 0, Math.PI / 4, 0 };
+
+            // Forward
+            Plane endPlane = opw.Forward(inputPose);
+
+            // Inverse
+            opw.Inverse(endPlane);
+
+            // At least one of the 8 solutions should match the input
+            bool matchFound = false;
+            for (int i = 0; i < 8; i++)
+            {
+                bool allMatch = true;
+                for (int j = 0; j < 6; j++)
+                {
+                    if (Math.Abs(opw.Solutions[i][j] - inputPose[j]) > AngleTolerance)
+                    {
+                        allMatch = false;
+                        break;
+                    }
+                }
+                if (allMatch) { matchFound = true; break; }
+            }
+
+            Assert.True(matchFound, "Forward-Inverse round-trip should recover the original joint angles in at least one solution");
+        }
+
+        [Fact]
+        public void OPWRoundTrip_NonTrivialPose_RecoversSolution()
+        {
+            OPWKinematics opw = CreateIRB120OPW();
+
+            double[] inputPose = { 0.5, 0.3, -Math.PI / 2 + 0.2, 0.1, Math.PI / 6, 0.4 };
+
+            // Forward
+            Plane endPlane = opw.Forward(inputPose);
+
+            // Inverse
+            opw.Inverse(endPlane);
+
+            // At least one of the 8 solutions should match the input
+            bool matchFound = false;
+            for (int i = 0; i < 8; i++)
+            {
+                bool allMatch = true;
+                for (int j = 0; j < 6; j++)
+                {
+                    if (Math.Abs(opw.Solutions[i][j] - inputPose[j]) > AngleTolerance)
+                    {
+                        allMatch = false;
+                        break;
+                    }
+                }
+                if (allMatch) { matchFound = true; break; }
+            }
+
+            Assert.True(matchFound, "Forward-Inverse round-trip should recover the original joint angles in at least one solution");
+        }
+
+        [Fact]
+        public void OPWRoundTrip_NegativeJointAngles_RecoversSolution()
+        {
+            OPWKinematics opw = CreateIRB120OPW();
+
+            double[] inputPose = { -0.3, -0.5, -Math.PI / 2 - 0.3, -0.2, Math.PI / 5, -0.5 };
+
+            Plane endPlane = opw.Forward(inputPose);
+            opw.Inverse(endPlane);
+
+            bool matchFound = false;
+            for (int i = 0; i < 8; i++)
+            {
+                bool allMatch = true;
+                for (int j = 0; j < 6; j++)
+                {
+                    if (Math.Abs(opw.Solutions[i][j] - inputPose[j]) > AngleTolerance)
+                    {
+                        allMatch = false;
+                        break;
+                    }
+                }
+                if (allMatch) { matchFound = true; break; }
+            }
+
+            Assert.True(matchFound, "Round-trip with negative angles should recover the original joint angles");
+        }
+        #endregion
+
+        #region Singularity Detection
+        [Fact]
+        public void OPWInverse_WristSingularity_J5NearZero_DetectsSingularity()
+        {
+            OPWKinematics opw = CreateIRB120OPW();
+
+            // Compute forward with J5 very close to 0 (wrist singularity)
+            double[] pose = { 0, 0, -Math.PI / 2, 0, 0.001, 0 };
+            Plane endPlane = opw.Forward(pose);
+            opw.Inverse(endPlane);
+
+            // At least some solutions should flag wrist singularity (J5 < 0.02 rad threshold)
+            bool anySingularity = opw.IsWristSingularity.Any(s => s);
+            Assert.True(anySingularity, "J5 near zero should trigger wrist singularity detection");
+        }
+
+        [Fact]
+        public void OPWInverse_ShoulderSingularity_TargetAtOrigin_DetectsSingularity()
+        {
+            OPWKinematics opw = CreateIRB120OPW();
+
+            // Shoulder singularity: wrist center at (0, 0, z) → directly above axis 1
+            // For IRB120 with A2=-70, B=0: wrist center is at (-70, 0, z) in zero config
+            // To get shoulder singularity, we need cx0 ≈ 0 and cy0 ≈ 0
+            // This happens when the wrist center is directly on the Z axis
+            // We can construct a plane where the wrist center maps to near (0,0,z)
+            // C4=72, so endPlane.Origin = wristCenter + C4 * ZAxis
+            Plane endPlane = new Plane(
+                new Point3d(0, 0, 934),
+                new Vector3d(1, 0, 0),
+                new Vector3d(0, 1, 0));
+
+            opw.Inverse(endPlane);
+
+            bool anySingularity = opw.IsShoulderSingularity.Any(s => s);
+            Assert.True(anySingularity, "Target directly above axis 1 should trigger shoulder singularity detection");
+        }
+
+        [Fact]
+        public void OPWInverse_NormalPosition_NoWristSingularity()
+        {
+            OPWKinematics opw = CreateIRB120OPW();
+
+            // J5 at pi/4 — well away from singularity
+            double[] pose = { 0, 0, -Math.PI / 2, 0, Math.PI / 4, 0 };
+            Plane endPlane = opw.Forward(pose);
+            opw.Inverse(endPlane);
+
+            // Solutions 0-3 (positive J5) should NOT have wrist singularity
+            // pi/4 ≈ 0.785 which is well above the 0.02 threshold
+            Assert.False(opw.IsWristSingularity[0], "J5 at pi/4 should not be a wrist singularity");
+        }
+        #endregion
+
+        #region OPW Angle Normalization
+        [Fact]
+        public void OPWInverse_SolutionsNormalized_WithinPiRange()
+        {
+            OPWKinematics opw = CreateIRB120OPW();
+
+            double[] pose = { 0, 0, -Math.PI / 2, 0, Math.PI / 4, 0 };
+            Plane endPlane = opw.Forward(pose);
+            opw.Inverse(endPlane);
+
+            // After offset/sign corrections, check solutions are in reasonable range
+            // The corrections may push values outside [-pi, pi] due to offset addition,
+            // but the internal angles should be normalized before corrections
+            for (int i = 0; i < 8; i++)
+            {
+                for (int j = 0; j < 6; j++)
+                {
+                    Assert.False(double.IsNaN(opw.Solutions[i][j]),
+                        $"Solution [{i}][{j}] should not be NaN");
+                }
+            }
+        }
+        #endregion
+
+        #region ForwardKinematics (Robot-level)
+        [Fact]
+        public void ForwardKinematics_AllZeroDegrees_TCPAtMountingFrame()
+        {
+            Robot robot = CreateTestRobot();
+            ForwardKinematics fk = new ForwardKinematics(robot, hideMesh: true);
+
+            fk.Calculate(new RobotJointPosition(0, 0, 0, 0, 0, 0));
+
+            // With all joints at 0° and tool0, TCP should be at mounting frame
+            // Mounting frame for IRB120: (374, 0, 630)
+            Assert.InRange(fk.TCPPlane.Origin.X, 374 - Tolerance, 374 + Tolerance);
+            Assert.InRange(fk.TCPPlane.Origin.Y, -Tolerance, Tolerance);
+            Assert.InRange(fk.TCPPlane.Origin.Z, 630 - Tolerance, 630 + Tolerance);
+        }
+
+        [Fact]
+        public void ForwardKinematics_Joint1At30Degrees_RotatesTCPInXYPlane()
+        {
+            Robot robot = CreateTestRobot();
+            ForwardKinematics fk = new ForwardKinematics(robot, hideMesh: true);
+
+            fk.Calculate(new RobotJointPosition(30, 0, 0, 0, 0, 0));
+
+            // Joint 1 rotates around Z. TCP at (374, 0, 630) rotated 30° around Z:
+            // x' = 374*cos(30°) ≈ 323.88, y' = 374*sin(30°) = 187.0, z' = 630
+            double expectedX = 374 * Math.Cos(30 * Math.PI / 180);
+            double expectedY = 374 * Math.Sin(30 * Math.PI / 180);
+            Assert.InRange(fk.TCPPlane.Origin.X, expectedX - Tolerance, expectedX + Tolerance);
+            Assert.InRange(fk.TCPPlane.Origin.Y, expectedY - Tolerance, expectedY + Tolerance);
+            Assert.InRange(fk.TCPPlane.Origin.Z, 630 - Tolerance, 630 + Tolerance);
+        }
+
+        [Fact]
+        public void ForwardKinematics_IsInLimits_WithinLimits_ReturnsTrue()
+        {
+            Robot robot = CreateTestRobot();
+            ForwardKinematics fk = new ForwardKinematics(robot, hideMesh: true);
+
+            // All zeros is within limits
+            fk.Calculate(new RobotJointPosition(0, 0, 0, 0, 0, 0));
+
+            Assert.True(fk.IsInLimits);
+            Assert.Empty(fk.ErrorText);
+        }
+
+        [Fact]
+        public void ForwardKinematics_IsInLimits_OutOfLimits_ReturnsFalse()
+        {
+            Robot robot = CreateTestRobot();
+            ForwardKinematics fk = new ForwardKinematics(robot, hideMesh: true);
+
+            // Joint 1 limit is [-165, 165], 200° is out of range
+            fk.Calculate(new RobotJointPosition(200, 0, 0, 0, 0, 0));
+
+            Assert.False(fk.IsInLimits);
+            Assert.NotEmpty(fk.ErrorText);
+        }
+
+        [Fact]
+        public void ForwardKinematics_PosedInternalAxisPlanes_HasSixPlanes()
+        {
+            Robot robot = CreateTestRobot();
+            ForwardKinematics fk = new ForwardKinematics(robot, hideMesh: true);
+
+            fk.Calculate(new RobotJointPosition(0, 0, 0, 0, 0, 0));
+
+            Assert.Equal(6, fk.PosedInternalAxisPlanes.Length);
+        }
+
+        [Fact]
+        public void ForwardKinematics_RobotTransforms_HasSevenElements()
+        {
+            Robot robot = CreateTestRobot();
+            ForwardKinematics fk = new ForwardKinematics(robot, hideMesh: true);
+
+            fk.Calculate(new RobotJointPosition(0, 0, 0, 0, 0, 0));
+
+            // 7 transforms: base + 6 joints
+            Assert.Equal(7, fk.RobotTransforms.Length);
+        }
+
+        [Fact]
+        public void ForwardKinematics_DifferentJointPositions_ProduceDifferentTCPPlanes()
+        {
+            Robot robot = CreateTestRobot();
+            ForwardKinematics fk = new ForwardKinematics(robot, hideMesh: true);
+
+            fk.Calculate(new RobotJointPosition(0, 0, 0, 0, 0, 0));
+            Point3d tcp1 = fk.TCPPlane.Origin;
+
+            fk.Calculate(new RobotJointPosition(45, 30, -20, 10, 45, 0));
+            Point3d tcp2 = fk.TCPPlane.Origin;
+
+            double distance = tcp1.DistanceTo(tcp2);
+            Assert.True(distance > 1.0, "Different joint positions should produce different TCP positions");
+        }
+        #endregion
+
+        #region ForwardKinematics Validity
+        [Fact]
+        public void ForwardKinematics_EmptyConstructor_IsNotValid()
+        {
+            ForwardKinematics fk = new ForwardKinematics();
+
+            Assert.False(fk.IsValid);
+        }
+
+        [Fact]
+        public void ForwardKinematics_WithRobot_BeforeCalculate_IsNotValid()
+        {
+            Robot robot = CreateTestRobot();
+            ForwardKinematics fk = new ForwardKinematics(robot, hideMesh: true);
+
+            // Before Calculate(), joint positions are null → not valid
+            Assert.False(fk.IsValid);
+        }
+
+        [Fact]
+        public void ForwardKinematics_ToString_AfterCalculate_ReturnsValid()
+        {
+            Robot robot = CreateTestRobot();
+            ForwardKinematics fk = new ForwardKinematics(robot, hideMesh: true);
+            fk.Calculate(new RobotJointPosition(0, 0, 0, 0, 0, 0));
+
+            Assert.Equal("Forward Kinematics", fk.ToString());
+        }
+        #endregion
+    }
+}

--- a/RobotComponents.Tests/Kinematics/KinematicsTests.cs
+++ b/RobotComponents.Tests/Kinematics/KinematicsTests.cs
@@ -6,7 +6,6 @@
 
 // System Libs
 using System;
-using System.Collections.Generic;
 using System.Linq;
 // Rhino Libs
 using Rhino.Geometry;
@@ -25,49 +24,12 @@ namespace RobotComponents.Tests.Kinematics
         private const double Tolerance = 1e-3;
         private const double AngleTolerance = 1e-6;
 
-        /// <summary>
-        /// Creates an OPW solver configured with IRB120-3/0.58 kinematic parameters.
-        /// </summary>
-        private static OPWKinematics CreateIRB120OPW()
-        {
-            OPWKinematics opw = new OPWKinematics();
-            opw.A1 = 0;
-            opw.B = 0;
-            opw.C1 = 290;
-            opw.C2 = 270;
-            opw.C4 = 72;
-            opw.A2 = -70;   // triggers UpdateRobotParameters
-            opw.C3 = 302;   // triggers UpdateRobotParameters with correct A2
-            opw.Offsets = new double[] { 0, 0, -Math.PI / 2, 0, 0, 0 };
-            opw.Signs = new int[] { 1, 1, 1, 1, 1, 1 };
-            return opw;
-        }
-
-        /// <summary>
-        /// Creates a test robot with IRB120-3/0.58 kinematic parameters and empty meshes.
-        /// </summary>
-        private static Robot CreateTestRobot()
-        {
-            List<Mesh> meshes = Enumerable.Range(0, 7).Select(_ => new Mesh()).ToList();
-            RobotKinematicParameters parameters = new RobotKinematicParameters(0, -70, 0, 0, 290, 270, 302, 72);
-            Interval[] limits = new Interval[]
-            {
-                new Interval(-165, 165),
-                new Interval(-110, 110),
-                new Interval(-110, 70),
-                new Interval(-160, 160),
-                new Interval(-120, 120),
-                new Interval(-400, 400)
-            };
-            return new Robot("TestRobot", meshes, parameters, limits, Plane.WorldXY, new RobotTool());
-        }
-
         #region OPW Forward Kinematics
         [Fact]
         [Trait("Category", "RequiresRhino")]
         public void OPWForward_AllZeroInternalAngles_ReturnsValidPlane()
         {
-            OPWKinematics opw = CreateIRB120OPW();
+            OPWKinematics opw = TestHelpers.CreateIRB120OPW();
 
             // Input [0, 0, -pi/2, 0, 0, 0] → internal angles all 0 (offset on joint 3)
             double[] pose = { 0, 0, -Math.PI / 2, 0, 0, 0 };
@@ -82,7 +44,7 @@ namespace RobotComponents.Tests.Kinematics
         [Trait("Category", "RequiresRhino")]
         public void OPWForward_AllZeroInternalAngles_CorrectPosition()
         {
-            OPWKinematics opw = CreateIRB120OPW();
+            OPWKinematics opw = TestHelpers.CreateIRB120OPW();
 
             // With all internal angles at 0, expected end plane:
             // wrist at (A2, 0, C1+C2+C3_contribution) → approximately (-70, 0, 862)
@@ -100,7 +62,7 @@ namespace RobotComponents.Tests.Kinematics
         [Trait("Category", "RequiresRhino")]
         public void OPWForward_AllZeroInternalAngles_OutputsWristPosition()
         {
-            OPWKinematics opw = CreateIRB120OPW();
+            OPWKinematics opw = TestHelpers.CreateIRB120OPW();
 
             double[] pose = { 0, 0, -Math.PI / 2, 0, 0, 0 };
             opw.Forward(pose, out Point3d wristPosition);
@@ -115,7 +77,7 @@ namespace RobotComponents.Tests.Kinematics
         [Trait("Category", "RequiresRhino")]
         public void OPWForward_Joint1Rotated_RotatesXYPosition()
         {
-            OPWKinematics opw = CreateIRB120OPW();
+            OPWKinematics opw = TestHelpers.CreateIRB120OPW();
 
             // Rotate joint 1 by pi/2 (90 degrees)
             double[] pose = { Math.PI / 2, 0, -Math.PI / 2, 0, 0, 0 };
@@ -131,7 +93,7 @@ namespace RobotComponents.Tests.Kinematics
         [Trait("Category", "RequiresRhino")]
         public void OPWForward_DifferentJointAngles_ProducesDifferentPosition()
         {
-            OPWKinematics opw = CreateIRB120OPW();
+            OPWKinematics opw = TestHelpers.CreateIRB120OPW();
 
             double[] pose1 = { 0, 0, -Math.PI / 2, 0, 0, 0 };
             double[] pose2 = { 0.5, 0.3, -Math.PI / 2 + 0.2, 0, Math.PI / 6, 0 };
@@ -147,7 +109,7 @@ namespace RobotComponents.Tests.Kinematics
         [Fact]
         public void OPWForward_TooFewJoints_ThrowsException()
         {
-            OPWKinematics opw = CreateIRB120OPW();
+            OPWKinematics opw = TestHelpers.CreateIRB120OPW();
 
             double[] pose = { 0, 0, 0 }; // Only 3 values
             Assert.Throws<Exception>(() => opw.Forward(pose));
@@ -159,7 +121,7 @@ namespace RobotComponents.Tests.Kinematics
         [Trait("Category", "RequiresRhino")]
         public void OPWInverse_ValidPlane_Produces8Solutions()
         {
-            OPWKinematics opw = CreateIRB120OPW();
+            OPWKinematics opw = TestHelpers.CreateIRB120OPW();
 
             Plane endPlane = new Plane(
                 new Point3d(-70, 0, 934),
@@ -177,7 +139,7 @@ namespace RobotComponents.Tests.Kinematics
         [Trait("Category", "RequiresRhino")]
         public void OPWInverse_SingularityFlags_HaveCorrectLength()
         {
-            OPWKinematics opw = CreateIRB120OPW();
+            OPWKinematics opw = TestHelpers.CreateIRB120OPW();
 
             Plane endPlane = new Plane(
                 new Point3d(-70, 0, 934),
@@ -197,7 +159,7 @@ namespace RobotComponents.Tests.Kinematics
         [Trait("Category", "RequiresRhino")]
         public void OPWRoundTrip_AllZeroInternalAngles_RecoversSolution()
         {
-            OPWKinematics opw = CreateIRB120OPW();
+            OPWKinematics opw = TestHelpers.CreateIRB120OPW();
 
             double[] inputPose = { 0, 0, -Math.PI / 2, 0, Math.PI / 4, 0 };
 
@@ -207,85 +169,35 @@ namespace RobotComponents.Tests.Kinematics
             // Inverse
             opw.Inverse(endPlane);
 
-            // At least one of the 8 solutions should match the input
-            bool matchFound = false;
-            for (int i = 0; i < 8; i++)
-            {
-                bool allMatch = true;
-                for (int j = 0; j < 6; j++)
-                {
-                    if (Math.Abs(opw.Solutions[i][j] - inputPose[j]) > AngleTolerance)
-                    {
-                        allMatch = false;
-                        break;
-                    }
-                }
-                if (allMatch) { matchFound = true; break; }
-            }
-
-            Assert.True(matchFound, "Forward-Inverse round-trip should recover the original joint angles in at least one solution");
+            TestHelpers.AssertAnySolutionMatches(opw.Solutions, inputPose, AngleTolerance);
         }
 
         [Fact]
         [Trait("Category", "RequiresRhino")]
         public void OPWRoundTrip_NonTrivialPose_RecoversSolution()
         {
-            OPWKinematics opw = CreateIRB120OPW();
+            OPWKinematics opw = TestHelpers.CreateIRB120OPW();
 
             double[] inputPose = { 0.5, 0.3, -Math.PI / 2 + 0.2, 0.1, Math.PI / 6, 0.4 };
 
-            // Forward
             Plane endPlane = opw.Forward(inputPose);
-
-            // Inverse
             opw.Inverse(endPlane);
 
-            // At least one of the 8 solutions should match the input
-            bool matchFound = false;
-            for (int i = 0; i < 8; i++)
-            {
-                bool allMatch = true;
-                for (int j = 0; j < 6; j++)
-                {
-                    if (Math.Abs(opw.Solutions[i][j] - inputPose[j]) > AngleTolerance)
-                    {
-                        allMatch = false;
-                        break;
-                    }
-                }
-                if (allMatch) { matchFound = true; break; }
-            }
-
-            Assert.True(matchFound, "Forward-Inverse round-trip should recover the original joint angles in at least one solution");
+            TestHelpers.AssertAnySolutionMatches(opw.Solutions, inputPose, AngleTolerance);
         }
 
         [Fact]
         [Trait("Category", "RequiresRhino")]
         public void OPWRoundTrip_NegativeJointAngles_RecoversSolution()
         {
-            OPWKinematics opw = CreateIRB120OPW();
+            OPWKinematics opw = TestHelpers.CreateIRB120OPW();
 
             double[] inputPose = { -0.3, -0.5, -Math.PI / 2 - 0.3, -0.2, Math.PI / 5, -0.5 };
 
             Plane endPlane = opw.Forward(inputPose);
             opw.Inverse(endPlane);
 
-            bool matchFound = false;
-            for (int i = 0; i < 8; i++)
-            {
-                bool allMatch = true;
-                for (int j = 0; j < 6; j++)
-                {
-                    if (Math.Abs(opw.Solutions[i][j] - inputPose[j]) > AngleTolerance)
-                    {
-                        allMatch = false;
-                        break;
-                    }
-                }
-                if (allMatch) { matchFound = true; break; }
-            }
-
-            Assert.True(matchFound, "Round-trip with negative angles should recover the original joint angles");
+            TestHelpers.AssertAnySolutionMatches(opw.Solutions, inputPose, AngleTolerance);
         }
         #endregion
 
@@ -294,7 +206,7 @@ namespace RobotComponents.Tests.Kinematics
         [Trait("Category", "RequiresRhino")]
         public void OPWInverse_WristSingularity_J5NearZero_DetectsSingularity()
         {
-            OPWKinematics opw = CreateIRB120OPW();
+            OPWKinematics opw = TestHelpers.CreateIRB120OPW();
 
             // Compute forward with J5 very close to 0 (wrist singularity)
             double[] pose = { 0, 0, -Math.PI / 2, 0, 0.001, 0 };
@@ -310,7 +222,7 @@ namespace RobotComponents.Tests.Kinematics
         [Trait("Category", "RequiresRhino")]
         public void OPWInverse_ShoulderSingularity_TargetAtOrigin_DetectsSingularity()
         {
-            OPWKinematics opw = CreateIRB120OPW();
+            OPWKinematics opw = TestHelpers.CreateIRB120OPW();
 
             // Shoulder singularity: wrist center at (0, 0, z) → directly above axis 1
             // For IRB120 with A2=-70, B=0: wrist center is at (-70, 0, z) in zero config
@@ -333,7 +245,7 @@ namespace RobotComponents.Tests.Kinematics
         [Trait("Category", "RequiresRhino")]
         public void OPWInverse_NormalPosition_NoWristSingularity()
         {
-            OPWKinematics opw = CreateIRB120OPW();
+            OPWKinematics opw = TestHelpers.CreateIRB120OPW();
 
             // J5 at pi/4 — well away from singularity
             double[] pose = { 0, 0, -Math.PI / 2, 0, Math.PI / 4, 0 };
@@ -351,7 +263,7 @@ namespace RobotComponents.Tests.Kinematics
         [Trait("Category", "RequiresRhino")]
         public void OPWInverse_SolutionsNormalized_WithinPiRange()
         {
-            OPWKinematics opw = CreateIRB120OPW();
+            OPWKinematics opw = TestHelpers.CreateIRB120OPW();
 
             double[] pose = { 0, 0, -Math.PI / 2, 0, Math.PI / 4, 0 };
             Plane endPlane = opw.Forward(pose);
@@ -376,7 +288,7 @@ namespace RobotComponents.Tests.Kinematics
         [Trait("Category", "RequiresRhino")]
         public void ForwardKinematics_AllZeroDegrees_TCPAtMountingFrame()
         {
-            Robot robot = CreateTestRobot();
+            Robot robot = TestHelpers.CreateIRB120Robot();
             ForwardKinematics fk = new ForwardKinematics(robot, hideMesh: true);
 
             fk.Calculate(new RobotJointPosition(0, 0, 0, 0, 0, 0));
@@ -392,7 +304,7 @@ namespace RobotComponents.Tests.Kinematics
         [Trait("Category", "RequiresRhino")]
         public void ForwardKinematics_Joint1At30Degrees_RotatesTCPInXYPlane()
         {
-            Robot robot = CreateTestRobot();
+            Robot robot = TestHelpers.CreateIRB120Robot();
             ForwardKinematics fk = new ForwardKinematics(robot, hideMesh: true);
 
             fk.Calculate(new RobotJointPosition(30, 0, 0, 0, 0, 0));
@@ -410,7 +322,7 @@ namespace RobotComponents.Tests.Kinematics
         [Trait("Category", "RequiresRhino")]
         public void ForwardKinematics_IsInLimits_WithinLimits_ReturnsTrue()
         {
-            Robot robot = CreateTestRobot();
+            Robot robot = TestHelpers.CreateIRB120Robot();
             ForwardKinematics fk = new ForwardKinematics(robot, hideMesh: true);
 
             // All zeros is within limits
@@ -424,7 +336,7 @@ namespace RobotComponents.Tests.Kinematics
         [Trait("Category", "RequiresRhino")]
         public void ForwardKinematics_IsInLimits_OutOfLimits_ReturnsFalse()
         {
-            Robot robot = CreateTestRobot();
+            Robot robot = TestHelpers.CreateIRB120Robot();
             ForwardKinematics fk = new ForwardKinematics(robot, hideMesh: true);
 
             // Joint 1 limit is [-165, 165], 200° is out of range
@@ -438,7 +350,7 @@ namespace RobotComponents.Tests.Kinematics
         [Trait("Category", "RequiresRhino")]
         public void ForwardKinematics_PosedInternalAxisPlanes_HasSixPlanes()
         {
-            Robot robot = CreateTestRobot();
+            Robot robot = TestHelpers.CreateIRB120Robot();
             ForwardKinematics fk = new ForwardKinematics(robot, hideMesh: true);
 
             fk.Calculate(new RobotJointPosition(0, 0, 0, 0, 0, 0));
@@ -450,7 +362,7 @@ namespace RobotComponents.Tests.Kinematics
         [Trait("Category", "RequiresRhino")]
         public void ForwardKinematics_RobotTransforms_HasSevenElements()
         {
-            Robot robot = CreateTestRobot();
+            Robot robot = TestHelpers.CreateIRB120Robot();
             ForwardKinematics fk = new ForwardKinematics(robot, hideMesh: true);
 
             fk.Calculate(new RobotJointPosition(0, 0, 0, 0, 0, 0));
@@ -463,7 +375,7 @@ namespace RobotComponents.Tests.Kinematics
         [Trait("Category", "RequiresRhino")]
         public void ForwardKinematics_DifferentJointPositions_ProduceDifferentTCPPlanes()
         {
-            Robot robot = CreateTestRobot();
+            Robot robot = TestHelpers.CreateIRB120Robot();
             ForwardKinematics fk = new ForwardKinematics(robot, hideMesh: true);
 
             fk.Calculate(new RobotJointPosition(0, 0, 0, 0, 0, 0));
@@ -490,7 +402,7 @@ namespace RobotComponents.Tests.Kinematics
         [Trait("Category", "RequiresRhino")]
         public void ForwardKinematics_WithRobot_BeforeCalculate_IsNotValid()
         {
-            Robot robot = CreateTestRobot();
+            Robot robot = TestHelpers.CreateIRB120Robot();
             ForwardKinematics fk = new ForwardKinematics(robot, hideMesh: true);
 
             // Before Calculate(), joint positions are null → not valid
@@ -501,7 +413,7 @@ namespace RobotComponents.Tests.Kinematics
         [Trait("Category", "RequiresRhino")]
         public void ForwardKinematics_ToString_AfterCalculate_ReturnsValid()
         {
-            Robot robot = CreateTestRobot();
+            Robot robot = TestHelpers.CreateIRB120Robot();
             ForwardKinematics fk = new ForwardKinematics(robot, hideMesh: true);
             fk.Calculate(new RobotJointPosition(0, 0, 0, 0, 0, 0));
 

--- a/RobotComponents.Tests/Kinematics/KinematicsTests.cs
+++ b/RobotComponents.Tests/Kinematics/KinematicsTests.cs
@@ -64,6 +64,7 @@ namespace RobotComponents.Tests.Kinematics
 
         #region OPW Forward Kinematics
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void OPWForward_AllZeroInternalAngles_ReturnsValidPlane()
         {
             OPWKinematics opw = CreateIRB120OPW();
@@ -78,6 +79,7 @@ namespace RobotComponents.Tests.Kinematics
         }
 
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void OPWForward_AllZeroInternalAngles_CorrectPosition()
         {
             OPWKinematics opw = CreateIRB120OPW();
@@ -95,6 +97,7 @@ namespace RobotComponents.Tests.Kinematics
         }
 
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void OPWForward_AllZeroInternalAngles_OutputsWristPosition()
         {
             OPWKinematics opw = CreateIRB120OPW();
@@ -109,6 +112,7 @@ namespace RobotComponents.Tests.Kinematics
         }
 
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void OPWForward_Joint1Rotated_RotatesXYPosition()
         {
             OPWKinematics opw = CreateIRB120OPW();
@@ -124,6 +128,7 @@ namespace RobotComponents.Tests.Kinematics
         }
 
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void OPWForward_DifferentJointAngles_ProducesDifferentPosition()
         {
             OPWKinematics opw = CreateIRB120OPW();
@@ -151,6 +156,7 @@ namespace RobotComponents.Tests.Kinematics
 
         #region OPW Inverse Kinematics
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void OPWInverse_ValidPlane_Produces8Solutions()
         {
             OPWKinematics opw = CreateIRB120OPW();
@@ -168,6 +174,7 @@ namespace RobotComponents.Tests.Kinematics
         }
 
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void OPWInverse_SingularityFlags_HaveCorrectLength()
         {
             OPWKinematics opw = CreateIRB120OPW();
@@ -187,6 +194,7 @@ namespace RobotComponents.Tests.Kinematics
 
         #region OPW Forward-Inverse Round-trip
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void OPWRoundTrip_AllZeroInternalAngles_RecoversSolution()
         {
             OPWKinematics opw = CreateIRB120OPW();
@@ -219,6 +227,7 @@ namespace RobotComponents.Tests.Kinematics
         }
 
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void OPWRoundTrip_NonTrivialPose_RecoversSolution()
         {
             OPWKinematics opw = CreateIRB120OPW();
@@ -251,6 +260,7 @@ namespace RobotComponents.Tests.Kinematics
         }
 
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void OPWRoundTrip_NegativeJointAngles_RecoversSolution()
         {
             OPWKinematics opw = CreateIRB120OPW();
@@ -281,6 +291,7 @@ namespace RobotComponents.Tests.Kinematics
 
         #region Singularity Detection
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void OPWInverse_WristSingularity_J5NearZero_DetectsSingularity()
         {
             OPWKinematics opw = CreateIRB120OPW();
@@ -296,6 +307,7 @@ namespace RobotComponents.Tests.Kinematics
         }
 
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void OPWInverse_ShoulderSingularity_TargetAtOrigin_DetectsSingularity()
         {
             OPWKinematics opw = CreateIRB120OPW();
@@ -318,6 +330,7 @@ namespace RobotComponents.Tests.Kinematics
         }
 
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void OPWInverse_NormalPosition_NoWristSingularity()
         {
             OPWKinematics opw = CreateIRB120OPW();
@@ -335,6 +348,7 @@ namespace RobotComponents.Tests.Kinematics
 
         #region OPW Angle Normalization
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void OPWInverse_SolutionsNormalized_WithinPiRange()
         {
             OPWKinematics opw = CreateIRB120OPW();
@@ -359,6 +373,7 @@ namespace RobotComponents.Tests.Kinematics
 
         #region ForwardKinematics (Robot-level)
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void ForwardKinematics_AllZeroDegrees_TCPAtMountingFrame()
         {
             Robot robot = CreateTestRobot();
@@ -374,6 +389,7 @@ namespace RobotComponents.Tests.Kinematics
         }
 
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void ForwardKinematics_Joint1At30Degrees_RotatesTCPInXYPlane()
         {
             Robot robot = CreateTestRobot();
@@ -391,6 +407,7 @@ namespace RobotComponents.Tests.Kinematics
         }
 
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void ForwardKinematics_IsInLimits_WithinLimits_ReturnsTrue()
         {
             Robot robot = CreateTestRobot();
@@ -404,6 +421,7 @@ namespace RobotComponents.Tests.Kinematics
         }
 
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void ForwardKinematics_IsInLimits_OutOfLimits_ReturnsFalse()
         {
             Robot robot = CreateTestRobot();
@@ -417,6 +435,7 @@ namespace RobotComponents.Tests.Kinematics
         }
 
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void ForwardKinematics_PosedInternalAxisPlanes_HasSixPlanes()
         {
             Robot robot = CreateTestRobot();
@@ -428,6 +447,7 @@ namespace RobotComponents.Tests.Kinematics
         }
 
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void ForwardKinematics_RobotTransforms_HasSevenElements()
         {
             Robot robot = CreateTestRobot();
@@ -440,6 +460,7 @@ namespace RobotComponents.Tests.Kinematics
         }
 
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void ForwardKinematics_DifferentJointPositions_ProduceDifferentTCPPlanes()
         {
             Robot robot = CreateTestRobot();
@@ -466,6 +487,7 @@ namespace RobotComponents.Tests.Kinematics
         }
 
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void ForwardKinematics_WithRobot_BeforeCalculate_IsNotValid()
         {
             Robot robot = CreateTestRobot();
@@ -476,6 +498,7 @@ namespace RobotComponents.Tests.Kinematics
         }
 
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void ForwardKinematics_ToString_AfterCalculate_ReturnsValid()
         {
             Robot robot = CreateTestRobot();

--- a/RobotComponents.Tests/Kinematics/RobotKinematicParametersTests.cs
+++ b/RobotComponents.Tests/Kinematics/RobotKinematicParametersTests.cs
@@ -1,0 +1,250 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This file is part of Robot Components
+// Project: https://github.com/RobotComponents/RobotComponents
+//
+// For license details, see the LICENSE file in the project root.
+
+// Rhino Libs
+using Rhino.Geometry;
+// Xunit Libs
+using Xunit;
+// Robot Components Libs
+using RobotComponents.ABB.Definitions;
+
+namespace RobotComponents.Tests.Kinematics
+{
+    public class RobotKinematicParametersTests
+    {
+        private const double Tolerance = 1e-6;
+
+        #region Constructor
+        [Fact]
+        public void Constructor_Empty_AllNaN()
+        {
+            RobotKinematicParameters p = new RobotKinematicParameters();
+
+            Assert.True(double.IsNaN(p.A1));
+            Assert.True(double.IsNaN(p.A2));
+            Assert.True(double.IsNaN(p.A3));
+            Assert.True(double.IsNaN(p.B));
+            Assert.True(double.IsNaN(p.C1));
+            Assert.True(double.IsNaN(p.C2));
+            Assert.True(double.IsNaN(p.C3));
+            Assert.True(double.IsNaN(p.C4));
+        }
+
+        [Fact]
+        public void Constructor_Empty_IsValidFalse()
+        {
+            RobotKinematicParameters p = new RobotKinematicParameters();
+
+            Assert.False(p.IsValid);
+        }
+
+        [Fact]
+        public void Constructor_WithValues_SetsAllProperties()
+        {
+            RobotKinematicParameters p = new RobotKinematicParameters(150, -100, 0, 135, 615, 705, 755, 85);
+
+            Assert.Equal(150, p.A1);
+            Assert.Equal(-100, p.A2);
+            Assert.Equal(0, p.A3);
+            Assert.Equal(135, p.B);
+            Assert.Equal(615, p.C1);
+            Assert.Equal(705, p.C2);
+            Assert.Equal(755, p.C3);
+            Assert.Equal(85, p.C4);
+        }
+
+        [Fact]
+        public void Constructor_WithValues_IsValidTrue()
+        {
+            RobotKinematicParameters p = new RobotKinematicParameters(0, -70, 0, 0, 290, 270, 302, 72);
+
+            Assert.True(p.IsValid);
+        }
+
+        [Fact]
+        public void Constructor_IRB120Parameters_CorrectValues()
+        {
+            // IRB120-3/0.58 kinematic parameters
+            RobotKinematicParameters p = new RobotKinematicParameters(0, -70, 0, 0, 290, 270, 302, 72);
+
+            Assert.Equal(0, p.A1);
+            Assert.Equal(-70, p.A2);
+            Assert.Equal(0, p.A3);
+            Assert.Equal(0, p.B);
+            Assert.Equal(290, p.C1);
+            Assert.Equal(270, p.C2);
+            Assert.Equal(302, p.C3);
+            Assert.Equal(72, p.C4);
+        }
+
+        [Fact]
+        public void Constructor_ZeroWristOffset_StandardSphericalWrist()
+        {
+            RobotKinematicParameters p = new RobotKinematicParameters(0, -70, 0, 0, 290, 270, 302, 72);
+
+            // A3 = 0 means standard spherical wrist (OPW solver)
+            Assert.Equal(0, p.A3);
+        }
+        #endregion
+
+        #region GetAxisPlanes
+        [Fact]
+        public void GetAxisPlanes_IRB120_ReturnsSixPlanes()
+        {
+            RobotKinematicParameters p = new RobotKinematicParameters(0, -70, 0, 0, 290, 270, 302, 72);
+            Plane[] planes = p.GetAxisPlanes(Plane.WorldXY, out _);
+
+            Assert.Equal(6, planes.Length);
+        }
+
+        [Fact]
+        public void GetAxisPlanes_IRB120_Plane0AtOrigin()
+        {
+            RobotKinematicParameters p = new RobotKinematicParameters(0, -70, 0, 0, 290, 270, 302, 72);
+            Plane[] planes = p.GetAxisPlanes(Plane.WorldXY, out _);
+
+            // Plane 0: (0, 0, 0) with Z-axis vertical
+            Assert.InRange(planes[0].Origin.X, -Tolerance, Tolerance);
+            Assert.InRange(planes[0].Origin.Y, -Tolerance, Tolerance);
+            Assert.InRange(planes[0].Origin.Z, -Tolerance, Tolerance);
+        }
+
+        [Fact]
+        public void GetAxisPlanes_IRB120_Plane1AtA1C1()
+        {
+            RobotKinematicParameters p = new RobotKinematicParameters(0, -70, 0, 0, 290, 270, 302, 72);
+            Plane[] planes = p.GetAxisPlanes(Plane.WorldXY, out _);
+
+            // Plane 1: (A1, 0, C1) = (0, 0, 290)
+            Assert.InRange(planes[1].Origin.X, -Tolerance, Tolerance);
+            Assert.InRange(planes[1].Origin.Z, 290 - Tolerance, 290 + Tolerance);
+        }
+
+        [Fact]
+        public void GetAxisPlanes_IRB120_Plane5AtWrist()
+        {
+            RobotKinematicParameters p = new RobotKinematicParameters(0, -70, 0, 0, 290, 270, 302, 72);
+            Plane[] planes = p.GetAxisPlanes(Plane.WorldXY, out _);
+
+            // Plane 5: (A1+C3+C4, -B, C1+C2-A2-A3) = (374, 0, 630)
+            Assert.InRange(planes[5].Origin.X, 374 - Tolerance, 374 + Tolerance);
+            Assert.InRange(planes[5].Origin.Y, -Tolerance, Tolerance);
+            Assert.InRange(planes[5].Origin.Z, 630 - Tolerance, 630 + Tolerance);
+        }
+
+        [Fact]
+        public void GetAxisPlanes_OutputsMountingFrame()
+        {
+            RobotKinematicParameters p = new RobotKinematicParameters(0, -70, 0, 0, 290, 270, 302, 72);
+            p.GetAxisPlanes(Plane.WorldXY, out Plane mountingFrame);
+
+            // Mounting frame at planes[5].Origin = (374, 0, 630)
+            Assert.InRange(mountingFrame.Origin.X, 374 - Tolerance, 374 + Tolerance);
+            Assert.InRange(mountingFrame.Origin.Z, 630 - Tolerance, 630 + Tolerance);
+        }
+
+        [Fact]
+        public void GetAxisPlanes_WithOffsetBase_TransformsPlanes()
+        {
+            RobotKinematicParameters p = new RobotKinematicParameters(0, -70, 0, 0, 290, 270, 302, 72);
+            Plane basePlane = new Plane(new Point3d(1000, 0, 0), Vector3d.XAxis, Vector3d.YAxis);
+            Plane[] planes = p.GetAxisPlanes(basePlane, out _);
+
+            // Plane 0 should be at base plane origin
+            Assert.InRange(planes[0].Origin.X, 1000 - Tolerance, 1000 + Tolerance);
+        }
+        #endregion
+
+        #region Round-trip
+        [Fact]
+        public void RoundTrip_ValuesToPlanesThenBackToValues_MatchesOriginal()
+        {
+            // Create parameters from values
+            RobotKinematicParameters original = new RobotKinematicParameters(0, -70, 0, 0, 290, 270, 302, 72);
+
+            // Generate axis planes
+            Plane[] planes = original.GetAxisPlanes(Plane.WorldXY, out _);
+
+            // Reconstruct parameters from planes
+            RobotKinematicParameters reconstructed = new RobotKinematicParameters(Plane.WorldXY, planes);
+
+            // Verify values match
+            Assert.InRange(reconstructed.A1, original.A1 - Tolerance, original.A1 + Tolerance);
+            Assert.InRange(reconstructed.A2, original.A2 - Tolerance, original.A2 + Tolerance);
+            Assert.InRange(reconstructed.A3, original.A3 - Tolerance, original.A3 + Tolerance);
+            Assert.InRange(reconstructed.B, original.B - Tolerance, original.B + Tolerance);
+            Assert.InRange(reconstructed.C1, original.C1 - Tolerance, original.C1 + Tolerance);
+            Assert.InRange(reconstructed.C2, original.C2 - Tolerance, original.C2 + Tolerance);
+            Assert.InRange(reconstructed.C3, original.C3 - Tolerance, original.C3 + Tolerance);
+            Assert.InRange(reconstructed.C4, original.C4 - Tolerance, original.C4 + Tolerance);
+        }
+
+        [Fact]
+        public void RoundTrip_LargeRobotParameters_MatchesOriginal()
+        {
+            // IRB6700-like parameters with non-zero lateral offset
+            RobotKinematicParameters original = new RobotKinematicParameters(320, -200, 0, 200, 780, 1075, 1142, 200);
+
+            Plane[] planes = original.GetAxisPlanes(Plane.WorldXY, out _);
+            RobotKinematicParameters reconstructed = new RobotKinematicParameters(Plane.WorldXY, planes);
+
+            Assert.InRange(reconstructed.A1, original.A1 - Tolerance, original.A1 + Tolerance);
+            Assert.InRange(reconstructed.A2, original.A2 - Tolerance, original.A2 + Tolerance);
+            Assert.InRange(reconstructed.B, original.B - Tolerance, original.B + Tolerance);
+            Assert.InRange(reconstructed.C1, original.C1 - Tolerance, original.C1 + Tolerance);
+            Assert.InRange(reconstructed.C2, original.C2 - Tolerance, original.C2 + Tolerance);
+            Assert.InRange(reconstructed.C3, original.C3 - Tolerance, original.C3 + Tolerance);
+            Assert.InRange(reconstructed.C4, original.C4 - Tolerance, original.C4 + Tolerance);
+        }
+        #endregion
+
+        #region Duplicate
+        [Fact]
+        public void Duplicate_PreservesAllValues()
+        {
+            RobotKinematicParameters original = new RobotKinematicParameters(0, -70, 0, 0, 290, 270, 302, 72);
+            RobotKinematicParameters copy = original.Duplicate();
+
+            Assert.Equal(original.A1, copy.A1);
+            Assert.Equal(original.A2, copy.A2);
+            Assert.Equal(original.A3, copy.A3);
+            Assert.Equal(original.B, copy.B);
+            Assert.Equal(original.C1, copy.C1);
+            Assert.Equal(original.C2, copy.C2);
+            Assert.Equal(original.C3, copy.C3);
+            Assert.Equal(original.C4, copy.C4);
+        }
+
+        [Fact]
+        public void Duplicate_EmptyParameters_PreservesNaN()
+        {
+            RobotKinematicParameters original = new RobotKinematicParameters();
+            RobotKinematicParameters copy = original.Duplicate();
+
+            Assert.True(double.IsNaN(copy.A1));
+            Assert.False(copy.IsValid);
+        }
+        #endregion
+
+        #region ToString
+        [Fact]
+        public void ToString_ValidParameters_ReturnsExpected()
+        {
+            RobotKinematicParameters p = new RobotKinematicParameters(0, -70, 0, 0, 290, 270, 302, 72);
+
+            Assert.Equal("Robot Kinematic Parameters", p.ToString());
+        }
+
+        [Fact]
+        public void ToString_InvalidParameters_ReturnsInvalid()
+        {
+            RobotKinematicParameters p = new RobotKinematicParameters();
+
+            Assert.Equal("Invalid Robot Kinematic Parameters", p.ToString());
+        }
+        #endregion
+    }
+}

--- a/RobotComponents.Tests/Kinematics/RobotKinematicParametersTests.cs
+++ b/RobotComponents.Tests/Kinematics/RobotKinematicParametersTests.cs
@@ -92,6 +92,7 @@ namespace RobotComponents.Tests.Kinematics
 
         #region GetAxisPlanes
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void GetAxisPlanes_IRB120_ReturnsSixPlanes()
         {
             RobotKinematicParameters p = new RobotKinematicParameters(0, -70, 0, 0, 290, 270, 302, 72);
@@ -101,6 +102,7 @@ namespace RobotComponents.Tests.Kinematics
         }
 
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void GetAxisPlanes_IRB120_Plane0AtOrigin()
         {
             RobotKinematicParameters p = new RobotKinematicParameters(0, -70, 0, 0, 290, 270, 302, 72);
@@ -113,6 +115,7 @@ namespace RobotComponents.Tests.Kinematics
         }
 
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void GetAxisPlanes_IRB120_Plane1AtA1C1()
         {
             RobotKinematicParameters p = new RobotKinematicParameters(0, -70, 0, 0, 290, 270, 302, 72);
@@ -124,6 +127,7 @@ namespace RobotComponents.Tests.Kinematics
         }
 
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void GetAxisPlanes_IRB120_Plane5AtWrist()
         {
             RobotKinematicParameters p = new RobotKinematicParameters(0, -70, 0, 0, 290, 270, 302, 72);
@@ -136,6 +140,7 @@ namespace RobotComponents.Tests.Kinematics
         }
 
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void GetAxisPlanes_OutputsMountingFrame()
         {
             RobotKinematicParameters p = new RobotKinematicParameters(0, -70, 0, 0, 290, 270, 302, 72);
@@ -147,6 +152,7 @@ namespace RobotComponents.Tests.Kinematics
         }
 
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void GetAxisPlanes_WithOffsetBase_TransformsPlanes()
         {
             RobotKinematicParameters p = new RobotKinematicParameters(0, -70, 0, 0, 290, 270, 302, 72);
@@ -160,6 +166,7 @@ namespace RobotComponents.Tests.Kinematics
 
         #region Round-trip
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void RoundTrip_ValuesToPlanesThenBackToValues_MatchesOriginal()
         {
             // Create parameters from values
@@ -183,6 +190,7 @@ namespace RobotComponents.Tests.Kinematics
         }
 
         [Fact]
+        [Trait("Category", "RequiresRhino")]
         public void RoundTrip_LargeRobotParameters_MatchesOriginal()
         {
             // IRB6700-like parameters with non-zero lateral offset

--- a/RobotComponents.Tests/TestHelpers.cs
+++ b/RobotComponents.Tests/TestHelpers.cs
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This file is part of Robot Components
+// Project: https://github.com/RobotComponents/RobotComponents
+//
+// For license details, see the LICENSE file in the project root.
+
+// System Libs
+using System;
+using System.Collections.Generic;
+using System.Linq;
+// Rhino Libs
+using Rhino.Geometry;
+// Robot Components Libs
+using RobotComponents.Generic.Kinematics;
+using RobotComponents.ABB.Definitions;
+
+namespace RobotComponents.Tests
+{
+    /// <summary>
+    /// Shared test helpers for creating test fixtures.
+    /// </summary>
+    internal static class TestHelpers
+    {
+        /// <summary>
+        /// Creates a test robot with IRB120-3/0.58 kinematic parameters and empty meshes.
+        /// Requires Rhino native library (new Mesh(), new RobotTool()).
+        /// </summary>
+        internal static Robot CreateIRB120Robot(Plane basePlane = default, RobotTool tool = null)
+        {
+            if (basePlane == default) basePlane = Plane.WorldXY;
+            if (tool == null) tool = new RobotTool();
+
+            List<Mesh> meshes = Enumerable.Range(0, 7).Select(_ => new Mesh()).ToList();
+            RobotKinematicParameters parameters = CreateIRB120Parameters();
+            Interval[] limits = CreateIRB120Limits();
+
+            return new Robot("TestRobot", meshes, parameters, limits, basePlane, tool);
+        }
+
+        /// <summary>
+        /// Creates IRB120-3/0.58 kinematic parameters.
+        /// </summary>
+        internal static RobotKinematicParameters CreateIRB120Parameters()
+        {
+            return new RobotKinematicParameters(0, -70, 0, 0, 290, 270, 302, 72);
+        }
+
+        /// <summary>
+        /// Creates IRB120 axis limits (degrees).
+        /// </summary>
+        internal static Interval[] CreateIRB120Limits()
+        {
+            return new Interval[]
+            {
+                new Interval(-165, 165),
+                new Interval(-110, 110),
+                new Interval(-110, 70),
+                new Interval(-160, 160),
+                new Interval(-120, 120),
+                new Interval(-400, 400)
+            };
+        }
+
+        /// <summary>
+        /// Creates an OPW solver configured with IRB120-3/0.58 kinematic parameters.
+        /// IMPORTANT: Property assignment order matters — A2 and C3 each trigger
+        /// UpdateRobotParameters(), so A2 must be set before C3 to ensure correct
+        /// derived values (psi3, k, k2).
+        /// </summary>
+        internal static OPWKinematics CreateIRB120OPW()
+        {
+            OPWKinematics opw = new OPWKinematics();
+            opw.A1 = 0;
+            opw.B = 0;
+            opw.C1 = 290;
+            opw.C2 = 270;
+            opw.C4 = 72;
+            opw.A2 = -70;   // triggers UpdateRobotParameters
+            opw.C3 = 302;   // triggers UpdateRobotParameters with correct A2
+            opw.Offsets = new double[] { 0, 0, -Math.PI / 2, 0, 0, 0 };
+            opw.Signs = new int[] { 1, 1, 1, 1, 1, 1 };
+            return opw;
+        }
+
+        /// <summary>
+        /// Asserts that at least one of the 8 OPW inverse solutions matches the expected
+        /// joint angles within the given tolerance.
+        /// </summary>
+        internal static void AssertAnySolutionMatches(double[][] solutions, double[] expected, double tolerance)
+        {
+            for (int i = 0; i < solutions.Length; i++)
+            {
+                bool allMatch = true;
+
+                for (int j = 0; j < 6; j++)
+                {
+                    if (Math.Abs(solutions[i][j] - expected[j]) > tolerance)
+                    {
+                        allMatch = false;
+                        break;
+                    }
+                }
+
+                if (allMatch) return;
+            }
+
+            throw new Xunit.Sdk.XunitException(
+                "No OPW inverse solution matched the expected joint angles within tolerance");
+        }
+    }
+}

--- a/tests-plan.md
+++ b/tests-plan.md
@@ -1,0 +1,277 @@
+# Comprehensive Test Suite Plan for RobotComponents
+
+## Context
+
+The project originally had **one test** (`RobotPresetTests.cs`) covering preset enum-to-class consistency. This plan adds structured tests across all layers, prioritized by risk and value. Phases 1, 2, 2b, and 3 are complete with **410 tests** across 25 test classes.
+
+## Test Infrastructure
+
+**Framework**: xUnit (already in use), Pester for PowerShell scripts
+**Project**: `RobotComponents.Tests/` (existing)
+**Pipeline scripts**: `.github/scripts/tests/` (new, Pester)
+
+### Project reference additions needed in `RobotComponents.Tests.csproj`
+
+Currently references: `RobotComponents`, `RobotComponents.ABB`, `RobotComponents.ABB.Presets`
+Add: `RobotComponents.ABB.Gh.Goos` (for serialization round-trip tests later, not in this phase)
+
+---
+
+## Phase 1: Utility & Helper Tests — COMPLETE (42 tests)
+
+### `HelperMethodTests.cs` — 30 tests
+
+- [x] **Quaternion / Plane round-trip**: `PlaneToQuaternion` then `QuaternionToPlane` returns original plane (within tolerance), including rotated planes
+- [x] **Known quaternion values**: identity quaternion (1,0,0,0) produces WorldXY plane; component overload matches Quaternion overload; XYZ overload sets correct origin
+- [x] **FlipPlaneX / FlipPlaneY**: verify axis negation, origin unchanged, normal flip on X
+- [x] **Slerp**: t=0 returns q1, t=1 returns q2, t=0.5 returns midpoint; clamping t<0 to 0, t>1 to 1
+- [x] **Lerp**: same boundary and clamping tests
+- [x] **DotProduct**: orthogonal quaternions produce 0, identical produce 1, opposite produce -1
+- [x] **ReplaceFirst**: replaces only first occurrence, no match returns original, empty search, replace with empty
+- [x] **SetRapidDataFromString**: parse VAR/LOCAL/TASK/CONST declarations; malformed input produces exception
+
+### `PresetHelperTests.cs` — 9 tests
+
+- [x] **GetRobotNameFromPresetName**: standard, CRB, IRB1010 special case, LID suffix
+- [x] **GetRobotClassNameFromName**: reverse of above, single-digit reach padding
+- [x] **Round-trip**: all presets name → className → name matches enum name
+
+### `VersionNumberingTests.cs` — 3 tests
+
+- [x] `CurrentVersion` string parses as valid `System.Version`
+- [x] `CurrentVersion` matches `Version.ToString()`
+- [x] Version has expected components (non-negative Major, Minor, Build)
+
+---
+
+## Phase 2: RAPID Code Generation Tests — COMPLETE (246 tests)
+
+### `SpeedDataTests.cs` — 34 tests
+
+- [x] Predefined speed mapping: exact (v5, v100) and nearest-snap (25→v30, 7→v5)
+- [x] Int overload matches double overload
+- [x] Custom constructor: 4-arg and 5-arg variants, default optional args
+- [x] `ToRAPID()` bracket format for custom and predefined
+- [x] `ToRAPIDDeclaration`: custom named → VAR declaration, predefined → empty, unnamed → empty, LOCAL/TASK scope, PERS variable type
+- [x] `ToRAPIDInstruction` returns empty
+- [x] `IsValid`: positive → true, zero TCP → false, negative ORI → false, zero LEAX → false
+- [x] `Duplicate` returns matching values
+- [x] `Parse` / `TryParse` round-trip and invalid input
+- [x] Static helpers: predefined names, values, data, enum-to-constructor mapping
+
+### `ZoneDataTests.cs` — 32 tests
+
+- [x] Predefined zones: fine point, z10, z0, nearest-snap (8→z10)
+- [x] Int overload matches double overload
+- [x] Custom constructor: named, unnamed, fine point
+- [x] `ToRAPID()`: fine vs fly-by point, 7-element arrays for fine/z10/z0
+- [x] `ToRAPIDDeclaration`: custom named, predefined, unnamed, LOCAL scope
+- [x] `ToRAPIDInstruction` returns empty
+- [x] `IsValid`: predefined, fine point, zero path zone, negative path zone
+- [x] `Duplicate`, `Parse` / `TryParse`, static helpers
+
+### `ConfigurationDataTests.cs` — 17 tests
+
+- [x] Constructor: 4-int, default all-zero, named
+- [x] `ToRAPID`: bracket format, zeros, negative values
+- [x] `ToRAPIDDeclaration`: named (CONST confdata), unnamed, VAR keyword
+- [x] `ToRAPIDInstruction` returns empty
+- [x] `Duplicate`, `Parse` / `TryParse`
+
+### `ExternalJointPositionTests.cs` — 17 tests
+
+- [x] Constructor: default all-9E9, single axis, two axes, named, NaN→default
+- [x] `ToRAPID`: all default, first axis set, decimal formatting
+- [x] `ToRAPIDDeclaration`: named (extjoint), unnamed
+- [x] `ToRAPIDInstruction` returns empty
+- [x] Indexer: int and char ('a'…'f') access
+- [x] `IsValid`, `Duplicate`, `Length` always 6
+
+### `JointTargetTests.cs` — 17 tests
+
+- [x] Constructor: with RobotJointPosition, named with all fields, named with RJP only
+- [x] `ToRAPID`: nested array format `[[rjp], [ejp]]`
+- [x] `ToRAPIDDeclaration`: named (jointtarget), unnamed
+- [x] `ToRAPIDInstruction` returns empty
+- [x] `IsValid`: valid positions true, default constructor false
+- [x] `Duplicate`, `Parse` / `TryParse`
+
+### `RobotTargetTests.cs` — 19 tests
+
+- [x] Plane-to-quaternion embedded in declaration (WorldXY → identity, translated plane)
+- [x] `ToRAPID` produces 4-element nested array with config data and external axes
+- [x] Named ConfigurationData uses variable name in output
+- [x] `ToRAPIDDeclaration`: named (robtarget), unnamed
+- [x] `ToRAPIDInstruction` returns empty
+- [x] `IsValid`: valid plane true, Unset plane false
+- [x] `Duplicate`, `Parse` / `TryParse`
+
+### Instruction Tests — 57 tests (split into individual files)
+
+Originally `InstructionTests.cs`, split into per-type test files for maintainability:
+
+**`SetDigitalOutputTests.cs`** — 9 tests
+- [x] Basic true/false, delay, sync, sync overrides delay, IsValid (name, null, empty), declaration empty
+
+**`WaitTimeTests.cs`** — 6 tests
+- [x] Basic, integer trailing zeros, InPos flag, IsValid (zero, negative), declaration empty
+
+**`WaitDigitalIOTests.cs`** — 8 tests
+- [x] WaitDI: basic true/false, MaxTime with TimeFlag true/false, IsValid (name, null)
+- [x] WaitDO: basic, MaxTime
+
+**`WaitAnalogIOTests.cs`** — 6 tests
+- [x] WaitAI: LessThan, GreaterThan, MaxTime, IsValid
+- [x] WaitAO: LessThan, MaxTime
+
+**`WaitGroupIOTests.cs`** — 5 tests
+- [x] WaitGI: basic, MaxTime, IsValid
+- [x] WaitGO: basic, MaxTime
+
+**`WaitRobTests.cs`** — 7 tests
+- [x] InPos, ZeroSpeed, default not valid, InPos valid, ZeroSpeed valid, both true not valid, declaration empty
+
+**`CodeLineAndCommentTests.cs`** — 16 tests
+- [x] CodeLine: instruction/declaration types, default type, IsValid (non-empty, empty, null)
+- [x] Comment: instruction/declaration types, default type, IsValid (non-empty, empty, null)
+
+### `MovementTests.cs` — 20 tests
+
+- [x] MoveAbsJ with JointTarget: correct instruction format, named target uses variable name
+- [x] MoveL with RobotTarget: correct instruction format
+- [x] MoveJ with RobotTarget: correct instruction format
+- [x] Predefined speed uses name (v100), custom named speed produces declaration
+- [x] Invalid combinations: JointTarget with MoveL/MoveJ throws
+- [x] IsValid: valid movement true, null target false
+- [x] MoveC with circular via-point: correct instruction format, unset circular point throws
+- [x] MoveLDO / MoveJDO / MoveCDO: Movement with SetDigitalOutput produces correct DO variant
+- [x] MoveAbsJ with DO produces separate SetDO (no MoveAbsJDO variant)
+- [x] `\ID` parameter: SyncID appended to instruction, default SyncID omitted
+- [x] `\T` parameter: Time appended to instruction, default Time omitted
+
+### `RobotJointPositionTests.cs` — 21 tests
+
+- [x] Constructor: default all-zero, 6-arg, named, NaN replaced with zero, list-of-doubles
+- [x] `ToRAPID`: 6-element bracket format, decimal formatting
+- [x] `ToRAPIDDeclaration`: named (robjoint), unnamed → empty, LOCAL/TASK scope
+- [x] `ToRAPIDInstruction` returns empty
+- [x] Indexer: int access [0]–[5], out-of-range throws
+- [x] `IsValid`, `Duplicate`
+- [x] `Parse` / `TryParse` round-trip, invalid input, CONST variable type
+
+### `RAPIDGeneratorTests.cs` — 12 tests
+
+- [x] Module structure: empty actions → MODULE/ENDMODULE, with action → PROC/ENDPROC, custom module name, RC version comment
+- [x] Deduplication: SpeedData and ZoneData with same name produce one declaration each
+- [x] Instruction ordering matches input order
+- [x] Declaration sorting alphabetical
+- [x] Optional sections: tooldata/wobjdata/loaddata inclusion flags
+- [x] Mixed actions: correct section layout (MODULE → declarations → PROC → instructions → ENDPROC → ENDMODULE)
+
+---
+
+## Phase 3: Definitions & Kinematics Tests — COMPLETE (121 tests)
+
+### `RobotTests.cs` — 21 tests
+
+- [x] Construct from kinematic parameters produces IsValid = true; empty → invalid
+- [x] WorldXY and offset base planes set correctly
+- [x] Axis planes: 6 planes, axis 1 at origin, axis 2 at C1 height, axis 3 at C1+C2
+- [x] Mounting frame at correct position (374, 0, 630) for IRB120
+- [x] Tool: tool0 valid, ToolPlane at mounting frame
+- [x] Properties: NumberOfAxes=6, limits, kinematic parameters, external axes empty, 8 meshes, IK/FK initialized
+- [x] Duplicate: independent copy, preserves parameters and limits, DuplicateMechanicalUnit
+- [x] ToString valid/invalid
+
+### `RobotToolTests.cs` — 25 tests
+
+- [x] Default tool: name "tool0", WorldXY planes, RobotHold=true
+- [x] Custom tool: attachment/tool plane, with LoadData
+- [x] `ToRAPID`: default format, custom position, robotHold false
+- [x] `ToRAPIDDeclaration`: default/LOCAL/TASK scope, tool0→empty, custom→declaration, empty name→empty
+- [x] IsValid: valid, empty name, unset attachment plane
+- [x] Duplicate: independent copy, without mesh
+- [x] Properties: datatype, scope, variableType, toString
+- [x] Parse/TryParse: valid, invalid, throws on bad input
+
+### `WorkObjectTests.cs` — 27 tests
+
+- [x] Default wobj: name "wobj0", WorldXY, FixedFrame=true
+- [x] Custom frame: name+objectFrame, with userFrame
+- [x] `ToRAPID`: default format, custom objectFrame, with userFrame quaternion
+- [x] `ToRAPIDDeclaration`: default/LOCAL scope, wobj0→empty, custom→declaration, empty name→empty
+- [x] IsValid: valid, empty name, null name
+- [x] FixedFrame: no external axis → true
+- [x] GlobalWorkObjectPlane: default→WorldXY, with userFrame→combined (150,0,0)
+- [x] Duplicate: independent copy, preserves all properties
+- [x] Properties: datatype, scope, variableType, toString
+- [x] Parse/TryParse: valid, invalid, throws on bad input
+
+### `KinematicsTests.cs` — 30 tests
+
+- [x] **OPW Forward**: all-zero angles → valid plane, correct position, wrist output, joint1 rotation, different angles, too few joints → exception
+- [x] **OPW Inverse**: 8 solutions, singularity flag arrays
+- [x] **OPW Round-trip**: all-zero, non-trivial pose, negative angles all recover original
+- [x] **Singularity detection**: wrist J5≈0, shoulder target at origin, normal → no singularity
+- [x] **Angle normalization**: no NaN values
+- [x] **ForwardKinematics with Robot**: all-zero TCP, joint1 rotation, in-limits check, 6 posed planes, 7 transforms, different positions
+- [x] **FK validity**: empty→invalid, before calculate→invalid, toString
+
+### `RobotKinematicParametersTests.cs` — 18 tests
+
+- [x] Construct from values then `GetAxisPlanes()` then construct from planes produces matching parameters
+- [x] Large robot (IRB6700-like) round-trip
+- [x] Empty constructor → NaN, invalid; value constructor → correct, valid
+- [x] IRB120 parameters match expected values, zero wrist offset
+- [x] GetAxisPlanes: 6 planes, plane0 at origin, plane1 at A1/C1, plane5 at wrist, mounting frame, offset base
+- [x] Duplicate: preserves values, preserves NaN
+- [x] ToString valid/invalid
+
+**Files created:**
+- `RobotComponents.Tests/Definitions/RobotTests.cs`
+- `RobotComponents.Tests/Definitions/RobotToolTests.cs`
+- `RobotComponents.Tests/Definitions/WorkObjectTests.cs`
+- `RobotComponents.Tests/Kinematics/KinematicsTests.cs`
+- `RobotComponents.Tests/Kinematics/RobotKinematicParametersTests.cs`
+
+---
+
+## Phase 4: CI/CD Pipeline Script Tests (low priority)
+
+Extract inline PowerShell from workflows into `.github/scripts/`, test with Pester.
+
+### Scripts to extract
+
+| Script | Source workflow | Logic |
+|--------|---------------|-------|
+| `Validate-Version.ps1` | `release.yml` | Parse tag + VersionNumbering.cs, compare |
+| `Collect-ReleaseFiles.ps1` | `release.yml`, `artifact-build.yml` | Gather .gha + DLLs into staging dir |
+| `Extract-Changelog.ps1` | `release.yml` | Parse CHANGELOG.md for release notes |
+
+### Pester tests
+
+- [ ] **`Validate-Version.Tests.ps1`**: matching/mismatching versions, malformed file, missing file
+- [ ] **`Collect-ReleaseFiles.Tests.ps1`**: all files present, missing .gha fails, missing DLL fails
+- [ ] **`Extract-Changelog.Tests.ps1`**: normal changelog, empty file, truncation at 10K chars
+
+**Files to create:**
+- `.github/scripts/Validate-Version.ps1`
+- `.github/scripts/Collect-ReleaseFiles.ps1`
+- `.github/scripts/Extract-Changelog.ps1`
+- `.github/scripts/tests/Validate-Version.Tests.ps1`
+- `.github/scripts/tests/Collect-ReleaseFiles.Tests.ps1`
+- `.github/scripts/tests/Extract-Changelog.Tests.ps1`
+
+**Files to modify:**
+- `.github/workflows/ci.yml` — add Pester test step
+- `.github/workflows/release.yml` — call extracted scripts
+- `.github/workflows/artifact-build.yml` — call extracted scripts
+
+---
+
+## Verification
+
+1. Build: `msbuild /t:Build /p:Configuration=Release`
+2. Run xUnit: `vstest.console.exe RobotComponents.Tests/bin/Release/net48/RobotComponents.Tests.dll`
+3. Run Pester locally: `Invoke-Pester .github/scripts/tests/ -Output Detailed`
+4. Push to branch and verify CI runs both xUnit and Pester steps


### PR DESCRIPTION
## Summary
- Adds **121 new unit tests** across 5 test files covering Definitions (Robot, RobotTool, WorkObject) and Kinematics (OPW, ForwardKinematics, RobotKinematicParameters)
- Shared `TestHelpers.cs` for IRB120 robot/OPW fixtures and round-trip assertions
- Updates tests-plan.md to mark Phase 3 complete

## New Test Files

| File | Tests | Coverage |
|------|-------|----------|
| `RobotToolTests.cs` | 25 | Constructor, ToRAPID, declarations, scope, Parse/TryParse, duplicate |
| `WorkObjectTests.cs` | 27 | Constructor, ToRAPID, declarations, GlobalWorkObjectPlane, Parse/TryParse |
| `RobotTests.cs` | 21 | Constructor, axis planes, mounting frame, tool, properties, duplicate |
| `RobotKinematicParametersTests.cs` | 18 | Constructor, GetAxisPlanes, values↔planes round-trip, duplicate |
| `KinematicsTests.cs` | 30 | OPW forward/inverse, round-trip, singularity detection, ForwardKinematics |

## Test plan
- [x] All tests build with zero errors
- [x] 14 non-Rhino tests pass in CI (Category!=RequiresRhino filter)
- [ ] All 121 tests pass on desktop with Rhino native available

🤖 Generated with [Claude Code](https://claude.com/claude-code)