### PR TITLE
Phase 4: Extract CI/CD scripts + Pester tests

### DIFF
--- a/.github/scripts/Collect-ReleaseFiles.ps1
+++ b/.github/scripts/Collect-ReleaseFiles.ps1
@@ -1,0 +1,59 @@
+# Collect-ReleaseFiles.ps1
+# Gather .gha, project DLLs, and LICENSE into a staging directory.
+# Optionally create a zip archive for releases.
+
+param(
+    [Parameter(Mandatory)]
+    [string]$Configuration,
+
+    [Parameter(Mandatory)]
+    [string]$OutputDir,
+
+    [string]$RepoRoot = ".",
+
+    [switch]$CreateZip,
+
+    [string]$Version = ""
+)
+
+$ErrorActionPreference = 'Stop'
+
+New-Item -ItemType Directory -Path $OutputDir -Force | Out-Null
+
+# Collect .gha from the Gh project
+$ghaBin = Join-Path $RepoRoot "RobotComponents.ABB.Gh" "bin" $Configuration "net48"
+Get-ChildItem -Path $ghaBin -Filter "*.gha" -ErrorAction SilentlyContinue |
+    Copy-Item -Destination $OutputDir
+
+# Collect all project DLLs (exclude test and GH2 assemblies)
+$projects = @(
+    "RobotComponents",
+    "RobotComponents.ABB",
+    "RobotComponents.ABB.Presets",
+    "RobotComponents.ABB.Gh.Goos",
+    "RobotComponents.ABB.Controllers"
+)
+foreach ($proj in $projects) {
+    $dll = Join-Path $RepoRoot $proj "bin" $Configuration "net48" "$proj.dll"
+    if (Test-Path $dll) {
+        Copy-Item $dll -Destination $OutputDir
+    }
+}
+
+# Include license
+$license = Join-Path $RepoRoot "LICENSE"
+if (Test-Path $license) {
+    Copy-Item $license -Destination $OutputDir
+}
+
+Write-Host "Staged files:"
+Get-ChildItem $OutputDir | Format-Table Name, Length
+
+if ($CreateZip) {
+    if ([string]::IsNullOrWhiteSpace($Version)) {
+        throw "Version is required when CreateZip is specified."
+    }
+    $zipPath = "RobotComponents-$Version.zip"
+    Compress-Archive -Path (Join-Path $OutputDir '*') -DestinationPath $zipPath -Force
+    Write-Host "Created: $zipPath"
+}

--- a/.github/scripts/Extract-Changelog.ps1
+++ b/.github/scripts/Extract-Changelog.ps1
@@ -1,0 +1,34 @@
+# Extract-Changelog.ps1
+# Parse CHANGELOG.md into release notes, taking the first N sections.
+
+param(
+    [Parameter(Mandatory)]
+    [string]$Tag,
+
+    [string]$ChangelogPath = "CHANGELOG.md",
+
+    [string]$OutputPath = "release-notes.md",
+
+    [int]$MaxSections = 5,
+
+    [int]$MaxLength = 10000
+)
+
+$ErrorActionPreference = 'Stop'
+
+$changelog = Get-Content $ChangelogPath -Raw -ErrorAction SilentlyContinue
+
+if (-not $changelog) {
+    $notes = "Release $Tag"
+} else {
+    $sections = $changelog -split '---'
+    $relevantSections = $sections | Select-Object -First $MaxSections
+    $notes = ($relevantSections -join "`n---`n").Trim()
+
+    if ($notes.Length -gt $MaxLength) {
+        $notes = $notes.Substring(0, $MaxLength) + "`n`n... (see CHANGELOG.md for full details)"
+    }
+}
+
+$notes | Out-File -FilePath $OutputPath -Encoding UTF8
+Write-Host "Release notes written to $OutputPath ($($notes.Length) chars)"

--- a/.github/scripts/Extract-Changelog.ps1
+++ b/.github/scripts/Extract-Changelog.ps1
@@ -18,7 +18,7 @@ $ErrorActionPreference = 'Stop'
 
 $changelog = Get-Content $ChangelogPath -Raw -ErrorAction SilentlyContinue
 
-if (-not $changelog) {
+if ([string]::IsNullOrWhiteSpace($changelog)) {
     $notes = "Release $Tag"
 } else {
     $sections = $changelog -split '---'

--- a/.github/scripts/Generate-InstallInstructions.ps1
+++ b/.github/scripts/Generate-InstallInstructions.ps1
@@ -1,0 +1,39 @@
+# Generate-InstallInstructions.ps1
+# Write static INSTALL.md content for release artifacts.
+
+param(
+    [Parameter(Mandatory)]
+    [string]$OutputPath
+)
+
+$ErrorActionPreference = 'Stop'
+
+$content = @"
+# Installation Instructions
+
+## Limitations
+- Only works for Rhino 8
+
+## Download and Install
+
+1. **Download** the latest release zip from this page
+
+2. **Unblock the zip file** (important to prevent Windows security warnings):
+   - Right-click the downloaded zip file
+   - Select **Properties**
+   - Check the **Unblock** checkbox at the bottom
+   - Click **OK**
+
+3. **Extract** the zip file contents
+
+4. **Install** the plugin:
+   - Open File Explorer and navigate to: ``%appdata%\Grasshopper\Libraries``
+   - Paste all extracted files into this folder
+
+5. **Restart** Rhino and Grasshopper
+
+The components should now be available in Grasshopper.
+"@
+
+$content | Out-File -FilePath $OutputPath -Encoding UTF8
+Write-Host "Install instructions written to $OutputPath"

--- a/.github/scripts/Validate-Version.ps1
+++ b/.github/scripts/Validate-Version.ps1
@@ -1,0 +1,28 @@
+# Validate-Version.ps1
+# Compares a git tag version against the CurrentVersion in VersionNumbering.cs
+
+param(
+    [Parameter(Mandatory)]
+    [string]$Tag,
+
+    [Parameter(Mandatory)]
+    [string]$VersionFilePath
+)
+
+$ErrorActionPreference = 'Stop'
+
+$tagVersion = $Tag -replace '^v', ''
+
+$versionFile = Get-Content $VersionFilePath -Raw
+if ($versionFile -match 'CurrentVersion\s*=\s*"([^"]+)"') {
+    $codeVersion = $Matches[1]
+} else {
+    throw "Could not parse version from $VersionFilePath"
+}
+
+Write-Host "Tag version:  $tagVersion"
+Write-Host "Code version: $codeVersion"
+
+if ($tagVersion -ne $codeVersion) {
+    throw "Tag version ($tagVersion) does not match $VersionFilePath ($codeVersion). Update VersionNumbering.cs before tagging."
+}

--- a/.github/tests/Collect-ReleaseFiles.Tests.ps1
+++ b/.github/tests/Collect-ReleaseFiles.Tests.ps1
@@ -1,0 +1,102 @@
+BeforeAll {
+    $script:ScriptPath = Join-Path $PSScriptRoot '..' 'scripts' 'Collect-ReleaseFiles.ps1'
+}
+
+Describe 'Collect-ReleaseFiles' {
+
+    BeforeEach {
+        # Build a fake repo tree in TestDrive
+        $script:RepoRoot = Join-Path $TestDrive 'repo'
+        $script:OutDir   = Join-Path $TestDrive 'staging'
+
+        # Create .gha
+        $ghaDir = Join-Path $script:RepoRoot 'RobotComponents.ABB.Gh' 'bin' 'Release' 'net48'
+        New-Item -Path $ghaDir -ItemType Directory -Force | Out-Null
+        '' | Set-Content (Join-Path $ghaDir 'RobotComponents.ABB.Gh.gha')
+
+        # Create project DLLs
+        $projects = @(
+            'RobotComponents',
+            'RobotComponents.ABB',
+            'RobotComponents.ABB.Presets',
+            'RobotComponents.ABB.Gh.Goos',
+            'RobotComponents.ABB.Controllers'
+        )
+        foreach ($proj in $projects) {
+            $dir = Join-Path $script:RepoRoot $proj 'bin' 'Release' 'net48'
+            New-Item -Path $dir -ItemType Directory -Force | Out-Null
+            '' | Set-Content (Join-Path $dir "$proj.dll")
+        }
+
+        # Create LICENSE
+        'MIT' | Set-Content (Join-Path $script:RepoRoot 'LICENSE')
+    }
+
+    It 'copies all expected files when all are present' {
+        & $script:ScriptPath -Configuration Release -OutputDir $script:OutDir -RepoRoot $script:RepoRoot
+
+        $files = Get-ChildItem $script:OutDir | Select-Object -ExpandProperty Name
+        $files | Should -Contain 'RobotComponents.ABB.Gh.gha'
+        $files | Should -Contain 'RobotComponents.dll'
+        $files | Should -Contain 'RobotComponents.ABB.dll'
+        $files | Should -Contain 'RobotComponents.ABB.Presets.dll'
+        $files | Should -Contain 'RobotComponents.ABB.Gh.Goos.dll'
+        $files | Should -Contain 'RobotComponents.ABB.Controllers.dll'
+        $files | Should -Contain 'LICENSE'
+        $files | Should -HaveCount 7
+    }
+
+    It 'skips missing DLLs without error' {
+        # Remove one DLL
+        Remove-Item (Join-Path $script:RepoRoot 'RobotComponents.ABB.Controllers' 'bin' 'Release' 'net48' 'RobotComponents.ABB.Controllers.dll')
+
+        { & $script:ScriptPath -Configuration Release -OutputDir $script:OutDir -RepoRoot $script:RepoRoot } | Should -Not -Throw
+
+        $files = Get-ChildItem $script:OutDir | Select-Object -ExpandProperty Name
+        $files | Should -Not -Contain 'RobotComponents.ABB.Controllers.dll'
+        $files | Should -HaveCount 6
+    }
+
+    It 'handles missing .gha gracefully' {
+        # Remove .gha file
+        Remove-Item (Join-Path $script:RepoRoot 'RobotComponents.ABB.Gh' 'bin' 'Release' 'net48' 'RobotComponents.ABB.Gh.gha')
+
+        { & $script:ScriptPath -Configuration Release -OutputDir $script:OutDir -RepoRoot $script:RepoRoot } | Should -Not -Throw
+
+        $files = Get-ChildItem $script:OutDir | Select-Object -ExpandProperty Name
+        $files | Should -Not -Contain 'RobotComponents.ABB.Gh.gha'
+    }
+
+    It 'skips LICENSE when not present' {
+        Remove-Item (Join-Path $script:RepoRoot 'LICENSE')
+
+        { & $script:ScriptPath -Configuration Release -OutputDir $script:OutDir -RepoRoot $script:RepoRoot } | Should -Not -Throw
+
+        $files = Get-ChildItem $script:OutDir | Select-Object -ExpandProperty Name
+        $files | Should -Not -Contain 'LICENSE'
+    }
+
+    It 'creates zip when CreateZip is specified' {
+        & $script:ScriptPath -Configuration Release -OutputDir $script:OutDir -RepoRoot $script:RepoRoot -CreateZip -Version 'v1.0.0'
+
+        Test-Path 'RobotComponents-v1.0.0.zip' | Should -BeTrue
+    }
+
+    It 'throws when CreateZip is used without Version' {
+        { & $script:ScriptPath -Configuration Release -OutputDir $script:OutDir -RepoRoot $script:RepoRoot -CreateZip } |
+            Should -Throw '*Version is required*'
+    }
+
+    It 'uses the specified Configuration for paths' {
+        # Create Debug DLL for one project
+        $debugDir = Join-Path $script:RepoRoot 'RobotComponents' 'bin' 'Debug' 'net48'
+        New-Item -Path $debugDir -ItemType Directory -Force | Out-Null
+        '' | Set-Content (Join-Path $debugDir 'RobotComponents.dll')
+
+        & $script:ScriptPath -Configuration Debug -OutputDir $script:OutDir -RepoRoot $script:RepoRoot
+
+        $files = Get-ChildItem $script:OutDir | Select-Object -ExpandProperty Name
+        # Should find the Debug DLL but not Release ones for other projects
+        $files | Should -Contain 'RobotComponents.dll'
+    }
+}

--- a/.github/tests/Collect-ReleaseFiles.Tests.ps1
+++ b/.github/tests/Collect-ReleaseFiles.Tests.ps1
@@ -50,7 +50,7 @@ Describe 'Collect-ReleaseFiles' {
         # Remove one DLL
         Remove-Item (Join-Path $script:RepoRoot 'RobotComponents.ABB.Controllers' 'bin' 'Release' 'net48' 'RobotComponents.ABB.Controllers.dll')
 
-        { & $script:ScriptPath -Configuration Release -OutputDir $script:OutDir -RepoRoot $script:RepoRoot } | Should -Not -Throw
+        & $script:ScriptPath -Configuration Release -OutputDir $script:OutDir -RepoRoot $script:RepoRoot
 
         $files = Get-ChildItem $script:OutDir | Select-Object -ExpandProperty Name
         $files | Should -Not -Contain 'RobotComponents.ABB.Controllers.dll'
@@ -61,7 +61,7 @@ Describe 'Collect-ReleaseFiles' {
         # Remove .gha file
         Remove-Item (Join-Path $script:RepoRoot 'RobotComponents.ABB.Gh' 'bin' 'Release' 'net48' 'RobotComponents.ABB.Gh.gha')
 
-        { & $script:ScriptPath -Configuration Release -OutputDir $script:OutDir -RepoRoot $script:RepoRoot } | Should -Not -Throw
+        & $script:ScriptPath -Configuration Release -OutputDir $script:OutDir -RepoRoot $script:RepoRoot
 
         $files = Get-ChildItem $script:OutDir | Select-Object -ExpandProperty Name
         $files | Should -Not -Contain 'RobotComponents.ABB.Gh.gha'
@@ -70,7 +70,7 @@ Describe 'Collect-ReleaseFiles' {
     It 'skips LICENSE when not present' {
         Remove-Item (Join-Path $script:RepoRoot 'LICENSE')
 
-        { & $script:ScriptPath -Configuration Release -OutputDir $script:OutDir -RepoRoot $script:RepoRoot } | Should -Not -Throw
+        & $script:ScriptPath -Configuration Release -OutputDir $script:OutDir -RepoRoot $script:RepoRoot
 
         $files = Get-ChildItem $script:OutDir | Select-Object -ExpandProperty Name
         $files | Should -Not -Contain 'LICENSE'

--- a/.github/tests/Collect-ReleaseFiles.Tests.ps1
+++ b/.github/tests/Collect-ReleaseFiles.Tests.ps1
@@ -5,9 +5,11 @@ BeforeAll {
 Describe 'Collect-ReleaseFiles' {
 
     BeforeEach {
-        # Build a fake repo tree in TestDrive
+        # Clean up from previous test runs (TestDrive persists between It blocks)
         $script:RepoRoot = Join-Path $TestDrive 'repo'
         $script:OutDir   = Join-Path $TestDrive 'staging'
+        Remove-Item -Path $script:RepoRoot -Recurse -Force -ErrorAction SilentlyContinue
+        Remove-Item -Path $script:OutDir -Recurse -Force -ErrorAction SilentlyContinue
 
         # Create .gha
         $ghaDir = Join-Path $script:RepoRoot 'RobotComponents.ABB.Gh' 'bin' 'Release' 'net48'

--- a/.github/tests/Extract-Changelog.Tests.ps1
+++ b/.github/tests/Extract-Changelog.Tests.ps1
@@ -1,0 +1,86 @@
+BeforeAll {
+    $script:ScriptPath = Join-Path $PSScriptRoot '..' 'scripts' 'Extract-Changelog.ps1'
+}
+
+Describe 'Extract-Changelog' {
+
+    It 'extracts first 5 sections from a normal changelog' {
+        $changelog = Join-Path $TestDrive 'CHANGELOG.md'
+        $output = Join-Path $TestDrive 'notes.md'
+
+        # Build 8 sections separated by ---
+        $sections = 1..8 | ForEach-Object { "- Change number $_`n  **Commit:** ``abc$_`` | **Date:** 2026-01-0$_" }
+        ($sections -join "`n---`n") | Set-Content $changelog
+
+        & $script:ScriptPath -Tag 'v3.2.1' -ChangelogPath $changelog -OutputPath $output
+
+        $content = Get-Content $output -Raw
+        $content | Should -Match 'Change number 1'
+        $content | Should -Match 'Change number 5'
+        $content | Should -Not -Match 'Change number 6'
+    }
+
+    It 'returns fallback when changelog is missing' {
+        $changelog = Join-Path $TestDrive 'NonExistent.md'
+        $output = Join-Path $TestDrive 'notes.md'
+
+        & $script:ScriptPath -Tag 'v3.2.1' -ChangelogPath $changelog -OutputPath $output
+
+        $content = Get-Content $output -Raw
+        $content.Trim() | Should -Be 'Release v3.2.1'
+    }
+
+    It 'returns fallback when changelog is empty' {
+        $changelog = Join-Path $TestDrive 'CHANGELOG.md'
+        $output = Join-Path $TestDrive 'notes.md'
+        '' | Set-Content $changelog
+
+        & $script:ScriptPath -Tag 'v3.2.1' -ChangelogPath $changelog -OutputPath $output
+
+        $content = Get-Content $output -Raw
+        $content.Trim() | Should -Be 'Release v3.2.1'
+    }
+
+    It 'truncates content exceeding MaxLength' {
+        $changelog = Join-Path $TestDrive 'CHANGELOG.md'
+        $output = Join-Path $TestDrive 'notes.md'
+
+        # Create a very long changelog (>500 chars per section, 20 sections)
+        $sections = 1..20 | ForEach-Object { "- " + ("A" * 500) + " change $_" }
+        ($sections -join "`n---`n") | Set-Content $changelog
+
+        & $script:ScriptPath -Tag 'v3.2.1' -ChangelogPath $changelog -OutputPath $output -MaxLength 200
+
+        $content = Get-Content $output -Raw
+        $content | Should -Match 'see CHANGELOG\.md for full details'
+    }
+
+    It 'takes fewer sections when file has less than MaxSections' {
+        $changelog = Join-Path $TestDrive 'CHANGELOG.md'
+        $output = Join-Path $TestDrive 'notes.md'
+
+        $sections = 1..3 | ForEach-Object { "- Change number $_" }
+        ($sections -join "`n---`n") | Set-Content $changelog
+
+        & $script:ScriptPath -Tag 'v1.0.0' -ChangelogPath $changelog -OutputPath $output -MaxSections 5
+
+        $content = Get-Content $output -Raw
+        $content | Should -Match 'Change number 1'
+        $content | Should -Match 'Change number 3'
+    }
+
+    It 'respects custom MaxSections parameter' {
+        $changelog = Join-Path $TestDrive 'CHANGELOG.md'
+        $output = Join-Path $TestDrive 'notes.md'
+
+        $sections = 1..8 | ForEach-Object { "- Change number $_" }
+        ($sections -join "`n---`n") | Set-Content $changelog
+
+        & $script:ScriptPath -Tag 'v1.0.0' -ChangelogPath $changelog -OutputPath $output -MaxSections 2
+
+        $content = Get-Content $output -Raw
+        $content | Should -Match 'Change number 1'
+        $content | Should -Match 'Change number 2'
+        $content | Should -Not -Match 'Change number 3'
+    }
+}

--- a/.github/tests/Generate-InstallInstructions.Tests.ps1
+++ b/.github/tests/Generate-InstallInstructions.Tests.ps1
@@ -1,0 +1,38 @@
+BeforeAll {
+    $script:ScriptPath = Join-Path $PSScriptRoot '..' 'scripts' 'Generate-InstallInstructions.ps1'
+}
+
+Describe 'Generate-InstallInstructions' {
+
+    It 'creates file with expected content' {
+        $output = Join-Path $TestDrive 'INSTALL.md'
+
+        & $script:ScriptPath -OutputPath $output
+
+        Test-Path $output | Should -BeTrue
+        $content = Get-Content $output -Raw
+        $content | Should -Match 'Installation Instructions'
+    }
+
+    It 'includes key installation sections' {
+        $output = Join-Path $TestDrive 'INSTALL.md'
+
+        & $script:ScriptPath -OutputPath $output
+
+        $content = Get-Content $output -Raw
+        $content | Should -Match 'Unblock'
+        $content | Should -Match 'Grasshopper\\Libraries'
+        $content | Should -Match 'Restart'
+    }
+
+    It 'overwrites existing file' {
+        $output = Join-Path $TestDrive 'INSTALL.md'
+        'old content' | Set-Content $output
+
+        & $script:ScriptPath -OutputPath $output
+
+        $content = Get-Content $output -Raw
+        $content | Should -Not -Match 'old content'
+        $content | Should -Match 'Installation Instructions'
+    }
+}

--- a/.github/tests/Validate-Version.Tests.ps1
+++ b/.github/tests/Validate-Version.Tests.ps1
@@ -1,0 +1,60 @@
+BeforeAll {
+    $script:ScriptPath = Join-Path $PSScriptRoot '..' 'scripts' 'Validate-Version.ps1'
+}
+
+Describe 'Validate-Version' {
+
+    It 'passes when tag matches code version' {
+        $file = Join-Path $TestDrive 'VersionNumbering.cs'
+        @'
+public static class VersionNumbering
+{
+    public const string CurrentVersion = "3.2.1";
+}
+'@ | Set-Content $file
+
+        { & $script:ScriptPath -Tag 'v3.2.1' -VersionFilePath $file } | Should -Not -Throw
+    }
+
+    It 'passes when tag has no v prefix' {
+        $file = Join-Path $TestDrive 'VersionNumbering.cs'
+        @'
+public static class VersionNumbering
+{
+    public const string CurrentVersion = "3.2.1";
+}
+'@ | Set-Content $file
+
+        { & $script:ScriptPath -Tag '3.2.1' -VersionFilePath $file } | Should -Not -Throw
+    }
+
+    It 'throws when versions do not match' {
+        $file = Join-Path $TestDrive 'VersionNumbering.cs'
+        @'
+public static class VersionNumbering
+{
+    public const string CurrentVersion = "3.2.1";
+}
+'@ | Set-Content $file
+
+        { & $script:ScriptPath -Tag 'v3.3.0' -VersionFilePath $file } | Should -Throw '*does not match*'
+    }
+
+    It 'throws when file has no CurrentVersion' {
+        $file = Join-Path $TestDrive 'VersionNumbering.cs'
+        @'
+public static class VersionNumbering
+{
+    public const string SomeOtherField = "hello";
+}
+'@ | Set-Content $file
+
+        { & $script:ScriptPath -Tag 'v3.2.1' -VersionFilePath $file } | Should -Throw '*Could not parse*'
+    }
+
+    It 'throws when file does not exist' {
+        $file = Join-Path $TestDrive 'NonExistent.cs'
+
+        { & $script:ScriptPath -Tag 'v3.2.1' -VersionFilePath $file } | Should -Throw
+    }
+}

--- a/.github/workflows/artifact-build.yml
+++ b/.github/workflows/artifact-build.yml
@@ -42,37 +42,10 @@ jobs:
 
       - name: Collect plugin files
         shell: pwsh
-        run: |
-          $config = "${{ inputs.configuration }}"
-          $outDir = "artifact-staging"
-          New-Item -ItemType Directory -Path $outDir -Force | Out-Null
-
-          # Collect .gha from the Gh project
-          $ghaBin = "RobotComponents.ABB.Gh\bin\$config\net48"
-          Get-ChildItem -Path $ghaBin -Filter "*.gha" -ErrorAction SilentlyContinue | Copy-Item -Destination $outDir
-
-          # Collect all project DLLs (exclude test and GH2 assemblies)
-          $projects = @(
-            "RobotComponents",
-            "RobotComponents.ABB",
-            "RobotComponents.ABB.Presets",
-            "RobotComponents.ABB.Gh.Goos",
-            "RobotComponents.ABB.Controllers"
-          )
-          foreach ($proj in $projects) {
-            $dll = "$proj\bin\$config\net48\$proj.dll"
-            if (Test-Path $dll) {
-              Copy-Item $dll -Destination $outDir
-            }
-          }
-
-          # Include license
-          if (Test-Path "LICENSE") {
-            Copy-Item "LICENSE" -Destination $outDir
-          }
-
-          Write-Host "Staged files:"
-          Get-ChildItem $outDir | Format-Table Name, Length
+        run: >
+          .\.github\scripts\Collect-ReleaseFiles.ps1
+          -Configuration "${{ inputs.configuration }}"
+          -OutputDir artifact-staging
 
       - name: Upload plugin artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,20 @@ jobs:
 
       - name: Run tests
         run: vstest.console.exe "RobotComponents.Tests\bin\Release\net48\RobotComponents.Tests.dll" /TestCaseFilter:"Category!=RequiresRhino" /Logger:"trx;LogFileName=TestResults.trx"
-        
+
+      - name: Run Pester tests
+        shell: pwsh
+        run: |
+          Install-Module -Name Pester -MinimumVersion 5.0 -Force -SkipPublisherCheck -Scope CurrentUser
+          $config = New-PesterConfiguration
+          $config.Run.Path = ".github/tests"
+          $config.Run.Exit = $true
+          $config.Output.Verbosity = "Detailed"
+          $config.TestResult.Enabled = $true
+          $config.TestResult.OutputFormat = "NUnitXml"
+          $config.TestResult.OutputPath = "PesterResults.xml"
+          Invoke-Pester -Configuration $config
+
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,25 +17,10 @@ jobs:
 
       - name: Validate tag matches VersionNumbering.cs
         shell: pwsh
-        run: |
-          $tag = "${{ github.ref_name }}"
-          $tagVersion = $tag -replace '^v', ''
-
-          $versionFile = Get-Content "RobotComponents\VersionNumbering.cs" -Raw
-          if ($versionFile -match 'CurrentVersion\s*=\s*"([^"]+)"') {
-            $codeVersion = $Matches[1]
-          } else {
-            Write-Error "Could not parse version from VersionNumbering.cs"
-            exit 1
-          }
-
-          Write-Host "Tag version:  $tagVersion"
-          Write-Host "Code version: $codeVersion"
-
-          if ($tagVersion -ne $codeVersion) {
-            Write-Error "Tag version ($tagVersion) does not match VersionNumbering.cs ($codeVersion). Update VersionNumbering.cs before tagging."
-            exit 1
-          }
+        run: >
+          .\.github\scripts\Validate-Version.ps1
+          -Tag "${{ github.ref_name }}"
+          -VersionFilePath "RobotComponents\VersionNumbering.cs"
 
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v2
@@ -57,101 +42,25 @@ jobs:
 
       - name: Collect release files
         shell: pwsh
-        run: |
-          $version = "${{ github.ref_name }}"
-          $outDir = "release-staging"
-          New-Item -ItemType Directory -Path $outDir -Force | Out-Null
-
-          # Collect .gha from the Gh project
-          $ghaBin = "RobotComponents.ABB.Gh\bin\Release\net48"
-          Get-ChildItem -Path $ghaBin -Filter "*.gha" -ErrorAction SilentlyContinue | Copy-Item -Destination $outDir
-
-          # Collect all project DLLs (exclude test and GH2 assemblies)
-          $projects = @(
-            "RobotComponents",
-            "RobotComponents.ABB",
-            "RobotComponents.ABB.Presets",
-            "RobotComponents.ABB.Gh.Goos",
-            "RobotComponents.ABB.Controllers"
-          )
-          foreach ($proj in $projects) {
-            $dll = "$proj\bin\Release\net48\$proj.dll"
-            if (Test-Path $dll) {
-              Copy-Item $dll -Destination $outDir
-            }
-          }
-
-          # Include license
-          if (Test-Path "LICENSE") {
-            Copy-Item "LICENSE" -Destination $outDir
-          }
-
-          Write-Host "Release files:"
-          Get-ChildItem $outDir | Format-Table Name, Length
-
-          # Create zip
-          $zipPath = "RobotComponents-$version.zip"
-          Compress-Archive -Path "$outDir\*" -DestinationPath $zipPath -Force
-          Write-Host "Created: $zipPath"
+        run: >
+          .\.github\scripts\Collect-ReleaseFiles.ps1
+          -Configuration Release
+          -OutputDir release-staging
+          -CreateZip
+          -Version "${{ github.ref_name }}"
 
       - name: Extract changelog for this version
         id: changelog
         shell: pwsh
-        run: |
-          $tag = "${{ github.ref_name }}"
-          $version = $tag -replace '^v', ''
-
-          # Read the full changelog
-          $changelog = Get-Content "CHANGELOG.md" -Raw -ErrorAction SilentlyContinue
-
-          if (-not $changelog) {
-            $notes = "Release $tag"
-          } else {
-            # Use the changelog content up to a reasonable length as release notes
-            # The changelog format uses --- separators between entries
-            $sections = $changelog -split '---'
-            $relevantSections = $sections | Select-Object -First 5
-            $notes = ($relevantSections -join "`n---`n").Trim()
-
-            if ($notes.Length -gt 10000) {
-              $notes = $notes.Substring(0, 10000) + "`n`n... (see CHANGELOG.md for full details)"
-            }
-          }
-
-          # Write to file for the release step
-          $notes | Out-File -FilePath "release-notes.md" -Encoding UTF8
+        run: >
+          .\.github\scripts\Extract-Changelog.ps1
+          -Tag "${{ github.ref_name }}"
 
       - name: Generate install instructions
         shell: pwsh
-        run: |
-          $content = @"
-          # Installation Instructions
-
-          ## Limitations
-          - Only works for Rhino 8
-
-          ## Download and Install
-
-          1. **Download** the latest release zip from this page
-
-          2. **Unblock the zip file** (important to prevent Windows security warnings):
-             - Right-click the downloaded zip file
-             - Select **Properties**
-             - Check the **Unblock** checkbox at the bottom
-             - Click **OK**
-
-          3. **Extract** the zip file contents
-
-          4. **Install** the plugin:
-             - Open File Explorer and navigate to: ``%appdata%\Grasshopper\Libraries``
-             - Paste all extracted files into this folder
-
-          5. **Restart** Rhino and Grasshopper
-
-          The components should now be available in Grasshopper.
-          "@
-
-          $content | Out-File -FilePath "release-staging\INSTALL.md" -Encoding UTF8
+        run: >
+          .\.github\scripts\Generate-InstallInstructions.ps1
+          -OutputPath "release-staging\INSTALL.md"
 
       - name: Create GitHub Release
         env:


### PR DESCRIPTION
## Summary
- Extract 4 inline PowerShell blocks from `release.yml` and 1 from `artifact-build.yml` into standalone `.github/scripts/` files
- Unify duplicated Collect-ReleaseFiles logic into a single parameterized script
- Add 21 Pester tests across 4 test files in `.github/tests/`
- Add Pester 5 test step to CI workflow

## Scripts
| Script | Purpose |
|---|---|
| `Validate-Version.ps1` | Compare git tag against VersionNumbering.cs |
| `Collect-ReleaseFiles.ps1` | Gather .gha + DLLs + LICENSE into staging dir |
| `Extract-Changelog.ps1` | Parse CHANGELOG.md into release notes |
| `Generate-InstallInstructions.ps1` | Write static INSTALL.md |

## Test plan
- [x] CI passes with both xUnit (410 tests) and Pester (21 tests)
- [x] Verify Pester test step appears in CI output
- [x] Trigger artifact-build workflow to verify script call works
- [ ] (Future) Verify release workflow on next tag push

🤖 Generated with [Claude Code](https://claude.com/claude-code)