### PR TITLE
Sanitize CodeLine to mitigate RAPID code injection (A03)

### DIFF
--- a/RobotComponents.ABB.Gh/Components/Code Generation/Dynamic/CodeLineComponent.cs
+++ b/RobotComponents.ABB.Gh/Components/Code Generation/Dynamic/CodeLineComponent.cs
@@ -107,7 +107,14 @@ namespace RobotComponents.ABB.Gh.Components.CodeGeneration
 
             for (int i = 0; i < lines.Length; i++)
             {
-                codeLines.Add(new CodeLine(lines[i], (CodeType)type));
+                CodeLine codeLine = new CodeLine(lines[i], (CodeType)type);
+
+                foreach (string warning in codeLine.Warnings)
+                {
+                    AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, warning);
+                }
+
+                codeLines.Add(codeLine);
             }
 
             // Sets Output

--- a/RobotComponents.ABB/Actions/Dynamic/CodeLine.cs
+++ b/RobotComponents.ABB/Actions/Dynamic/CodeLine.cs
@@ -251,7 +251,7 @@ namespace RobotComponents.ABB.Actions.Dynamic
         /// <summary>
         /// Gets the list of sanitization warnings for this code line.
         /// </summary>
-        public List<string> Warnings
+        public IReadOnlyList<string> Warnings
         {
             get { return _warnings; }
         }

--- a/RobotComponents.ABB/Actions/Dynamic/CodeLine.cs
+++ b/RobotComponents.ABB/Actions/Dynamic/CodeLine.cs
@@ -14,11 +14,13 @@
 
 // System Libs
 using System;
+using System.Collections.Generic;
 using System.Runtime.Serialization;
 using System.Security.Permissions;
 // RobotComponents Libs
 using RobotComponents.ABB.Definitions;
 using RobotComponents.ABB.Enumerations;
+using RobotComponents.ABB.Utils;
 
 namespace RobotComponents.ABB.Actions.Dynamic
 {
@@ -31,6 +33,7 @@ namespace RobotComponents.ABB.Actions.Dynamic
         #region fields
         private string _code;
         private CodeType _type;
+        private List<string> _warnings = new List<string>();
         #endregion
 
         #region (de)serialization
@@ -74,7 +77,9 @@ namespace RobotComponents.ABB.Actions.Dynamic
         /// <param name="code"> The custom RAPID code line. </param>
         public CodeLine(string code)
         {
-            _code = code;
+            RapidCodeLineSanitizer.SanitizeResult result = RapidCodeLineSanitizer.Sanitize(code);
+            _code = result.Code;
+            _warnings = result.Warnings;
             _type = CodeType.Instruction;
         }
 
@@ -85,18 +90,21 @@ namespace RobotComponents.ABB.Actions.Dynamic
         /// <param name="type"> The Code Type. </param>
         public CodeLine(string code, CodeType type)
         {
-            _code = code;
+            RapidCodeLineSanitizer.SanitizeResult result = RapidCodeLineSanitizer.Sanitize(code);
+            _code = result.Code;
+            _warnings = result.Warnings;
             _type = type;
         }
 
         /// <summary>
-        /// Initializes a new instance of the Code Line class by duplicating an existing Code Line instance. 
+        /// Initializes a new instance of the Code Line class by duplicating an existing Code Line instance.
         /// </summary>
         /// <param name="codeLine"> The Code Line instance to duplicate. </param>
         public CodeLine(CodeLine codeLine)
         {
             _code = codeLine.Code;
             _type = codeLine.Type;
+            _warnings = new List<string>(codeLine.Warnings);
         }
 
         /// <summary>
@@ -210,6 +218,7 @@ namespace RobotComponents.ABB.Actions.Dynamic
             {
                 if (_code == null) { return false; }
                 if (_code == "") { return false; }
+                if (_warnings.Count > 0) { return false; }
                 return true;
             }
         }
@@ -217,10 +226,26 @@ namespace RobotComponents.ABB.Actions.Dynamic
         /// <summary>
         /// Gets or sets the custom RAPID Code Line text.
         /// </summary>
+        /// <remarks>
+        /// Setting this property re-runs sanitization on the new value.
+        /// </remarks>
         public string Code
         {
             get { return _code; }
-            set { _code = value; }
+            set
+            {
+                RapidCodeLineSanitizer.SanitizeResult result = RapidCodeLineSanitizer.Sanitize(value);
+                _code = result.Code;
+                _warnings = result.Warnings;
+            }
+        }
+
+        /// <summary>
+        /// Gets the list of sanitization warnings for this code line.
+        /// </summary>
+        public List<string> Warnings
+        {
+            get { return _warnings; }
         }
 
         /// <summary>

--- a/RobotComponents.ABB/Actions/Dynamic/CodeLine.cs
+++ b/RobotComponents.ABB/Actions/Dynamic/CodeLine.cs
@@ -45,7 +45,10 @@ namespace RobotComponents.ABB.Actions.Dynamic
         protected CodeLine(SerializationInfo info, StreamingContext context)
         {
             // // Version version = (int)info.GetValue("Version", typeof(Version)); // <-- use this if the (de)serialization changes
-            _code = (string)info.GetValue("Code", typeof(string));
+            string code = (string)info.GetValue("Code", typeof(string));
+            RapidCodeLineSanitizer.SanitizeResult result = RapidCodeLineSanitizer.Sanitize(code);
+            _code = result.Code;
+            _warnings = result.Warnings;
             _type = (CodeType)info.GetValue("Code Type", typeof(CodeType));
         }
 
@@ -197,6 +200,11 @@ namespace RobotComponents.ABB.Actions.Dynamic
         /// <param name="RAPIDGenerator"> The RAPID Generator. </param>
         public void ToRAPIDGenerator(RAPIDGenerator RAPIDGenerator)
         {
+            if (_warnings.Count > 0)
+            {
+                return;
+            }
+
             if (_type == CodeType.Declaration)
             {
                 RAPIDGenerator.ProgramDeclarationCustomCodeLines.Add("    " + _code);

--- a/RobotComponents.ABB/Utils/RapidCodeLineSanitizer.cs
+++ b/RobotComponents.ABB/Utils/RapidCodeLineSanitizer.cs
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This file is part of Robot Components
+// Project: https://github.com/RobotComponents/RobotComponents
+//
+// For license details, see the LICENSE file in the project root.
+
+// System Libs
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+
+namespace RobotComponents.ABB.Utils
+{
+    /// <summary>
+    /// Provides sanitization for user-supplied RAPID code lines to prevent
+    /// injection of structural keywords that could break the generated module.
+    /// </summary>
+    public static class RapidCodeLineSanitizer
+    {
+        /// <summary>
+        /// RAPID structural keywords that open or close blocks. If injected into
+        /// a CodeLine they can break the MODULE / PROC structure produced by
+        /// <see cref="RobotComponents.ABB.Actions.RAPIDGenerator"/>.
+        /// Checked case-insensitively at word boundaries.
+        /// </summary>
+        private static readonly string[] _structuralKeywords = new string[]
+        {
+            // Block closers
+            "ENDPROC", "ENDMODULE", "ENDFUNC", "ENDTRAP",
+            "ENDTEST", "ENDWHILE", "ENDIF", "ENDFOR", "ENDRECORD",
+            // Block openers
+            "PROC", "MODULE", "FUNC", "TRAP", "RECORD"
+        };
+
+        /// <summary>
+        /// Sanitizes a user-provided RAPID code string.
+        /// </summary>
+        /// <param name="code"> The raw code string. </param>
+        /// <returns>
+        /// A <see cref="SanitizeResult"/> containing the cleaned code and any warnings.
+        /// </returns>
+        public static SanitizeResult Sanitize(string code)
+        {
+            List<string> warnings = new List<string>();
+
+            if (string.IsNullOrEmpty(code))
+            {
+                return new SanitizeResult(code, warnings);
+            }
+
+            // Strip newlines — a CodeLine must be a single line
+            if (code.Contains("\r") || code.Contains("\n"))
+            {
+                code = code.Replace("\r\n", " ").Replace("\r", " ").Replace("\n", " ");
+                warnings.Add("Newlines were removed from the code line. Each CodeLine should be a single RAPID statement.");
+            }
+
+            // Detect structural keywords that could break the RAPID module structure
+            for (int i = 0; i < _structuralKeywords.Length; i++)
+            {
+                string keyword = _structuralKeywords[i];
+                string pattern = @"\b" + keyword + @"\b";
+
+                if (Regex.IsMatch(code, pattern, RegexOptions.IgnoreCase))
+                {
+                    warnings.Add($"Code line contains the structural RAPID keyword \"{keyword}\" which could break the generated module structure.");
+                }
+            }
+
+            return new SanitizeResult(code, warnings);
+        }
+
+        /// <summary>
+        /// Contains the result of sanitizing a RAPID code line.
+        /// </summary>
+        public class SanitizeResult
+        {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="SanitizeResult"/> class.
+            /// </summary>
+            /// <param name="code"> The sanitized code string. </param>
+            /// <param name="warnings"> The list of warning messages. </param>
+            public SanitizeResult(string code, List<string> warnings)
+            {
+                Code = code;
+                Warnings = warnings;
+            }
+
+            /// <summary>
+            /// Gets the sanitized code string.
+            /// </summary>
+            public string Code { get; }
+
+            /// <summary>
+            /// Gets the list of warning messages generated during sanitization.
+            /// </summary>
+            public List<string> Warnings { get; }
+
+            /// <summary>
+            /// Gets a value indicating whether any warnings were generated.
+            /// </summary>
+            public bool HasWarnings
+            {
+                get { return Warnings.Count > 0; }
+            }
+        }
+    }
+}

--- a/RobotComponents.Tests/Actions/CodeLineAndCommentTests.cs
+++ b/RobotComponents.Tests/Actions/CodeLineAndCommentTests.cs
@@ -9,6 +9,7 @@ using Xunit;
 // Robot Components Libs
 using RobotComponents.ABB.Actions.Dynamic;
 using RobotComponents.ABB.Enumerations;
+using RobotComponents.ABB.Utils;
 
 namespace RobotComponents.Tests.Actions
 {
@@ -76,6 +77,184 @@ namespace RobotComponents.Tests.Actions
             CodeLine cl = new CodeLine();
 
             Assert.False(cl.IsValid);
+        }
+    }
+
+    public class CodeLineSanitizationTests
+    {
+        [Fact]
+        public void Sanitize_NormalCode_NoWarnings()
+        {
+            RapidCodeLineSanitizer.SanitizeResult result = RapidCodeLineSanitizer.Sanitize("MoveL p1, v100, fine, tool0;");
+
+            Assert.Equal("MoveL p1, v100, fine, tool0;", result.Code);
+            Assert.Empty(result.Warnings);
+        }
+
+        [Fact]
+        public void Sanitize_StripsNewlines()
+        {
+            RapidCodeLineSanitizer.SanitizeResult result = RapidCodeLineSanitizer.Sanitize("line1\nline2");
+
+            Assert.Equal("line1 line2", result.Code);
+            Assert.Single(result.Warnings);
+        }
+
+        [Fact]
+        public void Sanitize_StripsCarriageReturnNewline()
+        {
+            RapidCodeLineSanitizer.SanitizeResult result = RapidCodeLineSanitizer.Sanitize("line1\r\nline2");
+
+            Assert.Equal("line1 line2", result.Code);
+            Assert.Single(result.Warnings);
+        }
+
+        [Fact]
+        public void Sanitize_DetectsEndProc()
+        {
+            RapidCodeLineSanitizer.SanitizeResult result = RapidCodeLineSanitizer.Sanitize("ENDPROC");
+
+            Assert.True(result.HasWarnings);
+            Assert.Contains(result.Warnings, w => w.Contains("ENDPROC"));
+        }
+
+        [Fact]
+        public void Sanitize_DetectsEndModule()
+        {
+            RapidCodeLineSanitizer.SanitizeResult result = RapidCodeLineSanitizer.Sanitize("ENDMODULE");
+
+            Assert.True(result.HasWarnings);
+            Assert.Contains(result.Warnings, w => w.Contains("ENDMODULE"));
+        }
+
+        [Fact]
+        public void Sanitize_DetectsProc()
+        {
+            RapidCodeLineSanitizer.SanitizeResult result = RapidCodeLineSanitizer.Sanitize("PROC myproc()");
+
+            Assert.True(result.HasWarnings);
+            Assert.Contains(result.Warnings, w => w.Contains("PROC"));
+        }
+
+        [Fact]
+        public void Sanitize_DetectsCaseInsensitive()
+        {
+            RapidCodeLineSanitizer.SanitizeResult result = RapidCodeLineSanitizer.Sanitize("endproc");
+
+            Assert.True(result.HasWarnings);
+            Assert.Contains(result.Warnings, w => w.Contains("ENDPROC"));
+        }
+
+        [Fact]
+        public void Sanitize_AllowsProcInContext()
+        {
+            // "proc" as part of a longer word should NOT trigger a warning
+            RapidCodeLineSanitizer.SanitizeResult result = RapidCodeLineSanitizer.Sanitize("MoveL proc_target, v50, fine, tool0;");
+
+            Assert.False(result.HasWarnings);
+        }
+
+        [Fact]
+        public void Sanitize_MultipleIssues()
+        {
+            RapidCodeLineSanitizer.SanitizeResult result = RapidCodeLineSanitizer.Sanitize("ENDPROC\nENDMODULE");
+
+            // Should have: newline warning + ENDPROC warning + ENDMODULE warning
+            Assert.True(result.Warnings.Count >= 3);
+        }
+
+        [Fact]
+        public void Sanitize_NullInput_NoWarnings()
+        {
+            RapidCodeLineSanitizer.SanitizeResult result = RapidCodeLineSanitizer.Sanitize(null);
+
+            Assert.Null(result.Code);
+            Assert.Empty(result.Warnings);
+        }
+
+        [Fact]
+        public void Sanitize_EmptyInput_NoWarnings()
+        {
+            RapidCodeLineSanitizer.SanitizeResult result = RapidCodeLineSanitizer.Sanitize("");
+
+            Assert.Equal("", result.Code);
+            Assert.Empty(result.Warnings);
+        }
+
+        [Fact]
+        public void Sanitize_DetectsModule()
+        {
+            RapidCodeLineSanitizer.SanitizeResult result = RapidCodeLineSanitizer.Sanitize("MODULE evil");
+
+            Assert.True(result.HasWarnings);
+            Assert.Contains(result.Warnings, w => w.Contains("MODULE"));
+        }
+
+        [Fact]
+        public void Sanitize_DetectsTrap()
+        {
+            RapidCodeLineSanitizer.SanitizeResult result = RapidCodeLineSanitizer.Sanitize("TRAP myhandler");
+
+            Assert.True(result.HasWarnings);
+            Assert.Contains(result.Warnings, w => w.Contains("TRAP"));
+        }
+
+        [Fact]
+        public void CodeLine_WithStructuralKeyword_IsInvalid()
+        {
+            CodeLine cl = new CodeLine("ENDPROC");
+
+            Assert.False(cl.IsValid);
+            Assert.NotEmpty(cl.Warnings);
+        }
+
+        [Fact]
+        public void CodeLine_WithSafeCode_IsValid()
+        {
+            CodeLine cl = new CodeLine("MoveL p1, v100, fine, tool0;");
+
+            Assert.True(cl.IsValid);
+            Assert.Empty(cl.Warnings);
+        }
+
+        [Fact]
+        public void CodeLine_SetterSanitizes()
+        {
+            CodeLine cl = new CodeLine("safe code;");
+            Assert.True(cl.IsValid);
+
+            cl.Code = "ENDPROC";
+            Assert.False(cl.IsValid);
+            Assert.NotEmpty(cl.Warnings);
+        }
+
+        [Fact]
+        public void CodeLine_NewlinesSanitizedInOutput()
+        {
+            CodeLine cl = new CodeLine("MoveL p1;\nMoveL p2;");
+
+            // Newlines should be replaced with spaces
+            Assert.DoesNotContain("\n", cl.Code);
+            Assert.Equal("MoveL p1; MoveL p2;", cl.Code);
+        }
+
+        [Fact]
+        public void CodeLine_VarDeclaration_IsValid()
+        {
+            CodeLine cl = new CodeLine("VAR num x := 5;", CodeType.Declaration);
+
+            Assert.True(cl.IsValid);
+            Assert.Empty(cl.Warnings);
+        }
+
+        [Fact]
+        public void CodeLine_InjectionWithSemicolon_NoStructuralWarning()
+        {
+            // Semicolons are normal in RAPID — only structural keywords are flagged
+            CodeLine cl = new CodeLine("SetDO signal1, 1;");
+
+            Assert.True(cl.IsValid);
+            Assert.Empty(cl.Warnings);
         }
     }
 

--- a/RobotComponents.Tests/Actions/CodeLineAndCommentTests.cs
+++ b/RobotComponents.Tests/Actions/CodeLineAndCommentTests.cs
@@ -256,6 +256,24 @@ namespace RobotComponents.Tests.Actions
             Assert.True(cl.IsValid);
             Assert.Empty(cl.Warnings);
         }
+
+        [Fact]
+        public void CodeLine_FlaggedCode_ToRAPIDInstruction_StillReturnsCode()
+        {
+            // ToRAPIDInstruction returns the raw string (used for preview);
+            // the guard is in ToRAPIDGenerator
+            CodeLine cl = new CodeLine("ENDPROC");
+
+            Assert.Equal("ENDPROC", cl.ToRAPIDInstruction(null));
+        }
+
+        [Fact]
+        public void CodeLine_FlaggedCode_ToRAPIDDeclaration_StillReturnsCode()
+        {
+            CodeLine cl = new CodeLine("ENDMODULE", CodeType.Declaration);
+
+            Assert.Equal("ENDMODULE", cl.ToRAPIDDeclaration(null));
+        }
     }
 
     public class CommentTests


### PR DESCRIPTION
## Summary
- Adds `RapidCodeLineSanitizer` utility that strips newlines and detects structural RAPID keywords (`ENDPROC`, `ENDMODULE`, `PROC`, `MODULE`, `TRAP`, etc.) at word boundaries
- `CodeLine` constructors and `Code` setter now sanitize all input; `IsValid` returns `false` when warnings exist
- `CodeLineComponent` surfaces sanitization warnings in the Grasshopper UI via `AddRuntimeMessage`
- 19 new unit tests covering injection detection, newline stripping, word boundary correctness, and safe code passthrough

Closes #32

## Test plan
- [x] All 27 CodeLine tests pass (8 existing + 19 new)
- [x] Build succeeds with no new errors
- [x] CI passes on Windows runner
- [ ] Manual verification: safe RAPID code (`MoveL p1;`, `VAR num x;`) produces no warnings
- [ ] Manual verification: dangerous input (`ENDPROC`, multiline strings) shows warnings in GH component

🤖 Generated with [Claude Code](https://claude.com/claude-code)