### PR TITLE
Strip newlines from Comment to prevent RAPID breakout (A03)

### DIFF
--- a/RobotComponents.ABB/Actions/Dynamic/Comment.cs
+++ b/RobotComponents.ABB/Actions/Dynamic/Comment.cs
@@ -46,7 +46,7 @@ namespace RobotComponents.ABB.Actions.Dynamic
         protected Comment(SerializationInfo info, StreamingContext context)
         {
             // // Version version = (int)info.GetValue("Version", typeof(Version)); // <-- use this if the (de)serialization changes
-            _comment = (string)info.GetValue("Comment", typeof(string));
+            _comment = StripNewlines((string)info.GetValue("Comment", typeof(string)));
             _type = (CodeType)info.GetValue("Code Type", typeof(CodeType));
         }
 
@@ -78,7 +78,7 @@ namespace RobotComponents.ABB.Actions.Dynamic
         /// <param name="comment"> The comment. </param>
         public Comment(string comment)
         {
-            _comment = comment;
+            _comment = StripNewlines(comment);
             _type = CodeType.Instruction;
         }
 
@@ -89,7 +89,7 @@ namespace RobotComponents.ABB.Actions.Dynamic
         /// <param name="type"> The Code Type. </param>
         public Comment(string comment, CodeType type)
         {
-            _comment = comment;
+            _comment = StripNewlines(comment);
             _type = type;
         }
 
@@ -138,6 +138,27 @@ namespace RobotComponents.ABB.Actions.Dynamic
         #endregion
 
         #region method
+        /// <summary>
+        /// Strips newline characters from the given string to prevent
+        /// RAPID comment breakout injection.
+        /// </summary>
+        /// <param name="text"> The input text. </param>
+        /// <returns> The text with newlines replaced by spaces, or null if input is null. </returns>
+        private static string StripNewlines(string text)
+        {
+            if (string.IsNullOrEmpty(text))
+            {
+                return text;
+            }
+
+            if (text.Contains("\r") || text.Contains("\n"))
+            {
+                return text.Replace("\r\n", " ").Replace("\r", " ").Replace("\n", " ");
+            }
+
+            return text;
+        }
+
         /// <summary>
         /// Returns a string that represents the current object.
         /// </summary>
@@ -235,10 +256,13 @@ namespace RobotComponents.ABB.Actions.Dynamic
         /// <summary>
         /// Gets or sets the comment text.
         /// </summary>
+        /// <remarks>
+        /// Setting this property strips newlines to prevent RAPID comment breakout.
+        /// </remarks>
         public string Com
         {
             get { return _comment; }
-            set { _comment = value; }
+            set { _comment = StripNewlines(value); }
         }
 
         /// <summary>

--- a/RobotComponents.ABB/Actions/Dynamic/Comment.cs
+++ b/RobotComponents.ABB/Actions/Dynamic/Comment.cs
@@ -99,7 +99,7 @@ namespace RobotComponents.ABB.Actions.Dynamic
         /// <param name="comment"> The Comment instance to duplicate. </param>
         public Comment(Comment comment)
         {
-            _comment = comment.Com;
+            _comment = StripNewlines(comment.Com);
             _type = comment.Type;
         }
 

--- a/RobotComponents.Tests/Actions/CodeLineAndCommentTests.cs
+++ b/RobotComponents.Tests/Actions/CodeLineAndCommentTests.cs
@@ -144,5 +144,69 @@ namespace RobotComponents.Tests.Actions
 
             Assert.False(c.IsValid);
         }
+
+        [Fact]
+        public void NewlineStripped_SingleArg()
+        {
+            Comment c = new Comment("line1\nMoveL dangerous;");
+
+            Assert.DoesNotContain("\n", c.Com);
+            Assert.Equal("! line1 MoveL dangerous;", c.ToRAPIDInstruction(null));
+        }
+
+        [Fact]
+        public void NewlineStripped_TwoArg()
+        {
+            Comment c = new Comment("line1\r\nline2", CodeType.Declaration);
+
+            Assert.DoesNotContain("\r", c.Com);
+            Assert.DoesNotContain("\n", c.Com);
+            Assert.Equal("! line1 line2", c.ToRAPIDDeclaration(null));
+        }
+
+        [Fact]
+        public void SetterStripsNewlines()
+        {
+            Comment c = new Comment("safe");
+            c.Com = "text\ninjected;";
+
+            Assert.DoesNotContain("\n", c.Com);
+            Assert.Equal("text injected;", c.Com);
+        }
+
+        [Fact]
+        public void NullComment_NoException()
+        {
+            Comment c = new Comment();
+            c.Com = null;
+
+            Assert.Null(c.Com);
+        }
+
+        [Fact]
+        public void EmptyComment_NoException()
+        {
+            Comment c = new Comment("");
+
+            Assert.Equal("", c.Com);
+        }
+
+        [Fact]
+        public void NoNewline_Unchanged()
+        {
+            Comment c = new Comment("normal comment text");
+
+            Assert.Equal("normal comment text", c.Com);
+            Assert.Equal("! normal comment text", c.ToRAPIDInstruction(null));
+        }
+
+        [Fact]
+        public void CarriageReturn_Stripped()
+        {
+            Comment c = new Comment("line1\rline2");
+
+            Assert.DoesNotContain("\r", c.Com);
+            Assert.Equal("line1 line2", c.Com);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Adds `StripNewlines` helper to `Comment` class that replaces `\r\n`, `\r`, `\n` with spaces
- Applied in all four constructors (single-arg, two-arg, copy, deserialization) and the `Com` setter
- Prevents a newline in comment text from breaking out of the `! ` prefix and injecting executable RAPID instructions
- 7 new unit tests covering newline stripping, setter sanitization, null/empty handling, and safe passthrough

Closes #33

## Test plan
- [x] All 15 Comment tests pass (8 existing + 7 new)
- [x] Build succeeds with no new errors
- [x] CI passes on Windows runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)