### PR TITLE
Sanitize signal names to prevent RAPID injection (A03)

### DIFF
--- a/RobotComponents.ABB/Actions/Instructions/PulseDigitalOutput.cs
+++ b/RobotComponents.ABB/Actions/Instructions/PulseDigitalOutput.cs
@@ -173,11 +173,7 @@ namespace RobotComponents.ABB.Actions.Instructions
         /// </returns>
         public string ToRAPIDInstruction(Robot robot)
         {
-            if (!HelperMethods.IsValidRapidIdentifier(_name))
-            {
-                throw new InvalidOperationException(
-                    $"Cannot generate RAPID instruction: '{_name}' is not a valid RAPID identifier.");
-            }
+            HelperMethods.ThrowIfInvalidRapidIdentifier(_name);
 
             if (_high == false)
             {

--- a/RobotComponents.ABB/Actions/Instructions/PulseDigitalOutput.cs
+++ b/RobotComponents.ABB/Actions/Instructions/PulseDigitalOutput.cs
@@ -15,6 +15,7 @@ using System.Runtime.Serialization;
 using System.Security.Permissions;
 // RobotComponents Libs
 using RobotComponents.ABB.Definitions;
+using RobotComponents.ABB.Utils;
 
 namespace RobotComponents.ABB.Actions.Instructions
 {
@@ -172,6 +173,12 @@ namespace RobotComponents.ABB.Actions.Instructions
         /// </returns>
         public string ToRAPIDInstruction(Robot robot)
         {
+            if (!HelperMethods.IsValidRapidIdentifier(_name))
+            {
+                throw new InvalidOperationException(
+                    $"Cannot generate RAPID instruction: '{_name}' is not a valid RAPID identifier.");
+            }
+
             if (_high == false)
             {
                 return $"PulseDO \\PLength:={_length:#.###}, {_name};";
@@ -205,6 +212,7 @@ namespace RobotComponents.ABB.Actions.Instructions
             {
                 if (_name == null) { return false; }
                 if (_name == "") { return false; }
+                if (!HelperMethods.IsValidRapidIdentifier(_name)) { return false; }
                 if (_length < 0.001) { return false; }
                 if (_length > 2000) { return false; }
                 return true;

--- a/RobotComponents.ABB/Actions/Instructions/SetAnalogOutput.cs
+++ b/RobotComponents.ABB/Actions/Instructions/SetAnalogOutput.cs
@@ -167,11 +167,7 @@ namespace RobotComponents.ABB.Actions.Instructions
         /// </returns>
         public string ToRAPIDInstruction(Robot robot)
         {
-            if (!HelperMethods.IsValidRapidIdentifier(_name))
-            {
-                throw new InvalidOperationException(
-                    $"Cannot generate RAPID instruction: '{_name}' is not a valid RAPID identifier.");
-            }
+            HelperMethods.ThrowIfInvalidRapidIdentifier(_name);
 
             return $"SetAO {_name}, {_value};";
         }

--- a/RobotComponents.ABB/Actions/Instructions/SetAnalogOutput.cs
+++ b/RobotComponents.ABB/Actions/Instructions/SetAnalogOutput.cs
@@ -15,6 +15,7 @@ using System.Runtime.Serialization;
 using System.Security.Permissions;
 // RobotComponents Libs
 using RobotComponents.ABB.Definitions;
+using RobotComponents.ABB.Utils;
 
 namespace RobotComponents.ABB.Actions.Instructions
 {
@@ -166,6 +167,12 @@ namespace RobotComponents.ABB.Actions.Instructions
         /// </returns>
         public string ToRAPIDInstruction(Robot robot)
         {
+            if (!HelperMethods.IsValidRapidIdentifier(_name))
+            {
+                throw new InvalidOperationException(
+                    $"Cannot generate RAPID instruction: '{_name}' is not a valid RAPID identifier.");
+            }
+
             return $"SetAO {_name}, {_value};";
         }
 
@@ -192,6 +199,7 @@ namespace RobotComponents.ABB.Actions.Instructions
             {
                 if (_name == null) { return false; }
                 if (_name == "") { return false; }
+                if (!HelperMethods.IsValidRapidIdentifier(_name)) { return false; }
                 return true;
             }
         }

--- a/RobotComponents.ABB/Actions/Instructions/SetDigitalOutput.cs
+++ b/RobotComponents.ABB/Actions/Instructions/SetDigitalOutput.cs
@@ -18,6 +18,7 @@ using System.Runtime.Serialization;
 using System.Security.Permissions;
 // RobotComponents Libs
 using RobotComponents.ABB.Definitions;
+using RobotComponents.ABB.Utils;
 
 namespace RobotComponents.ABB.Actions.Instructions
 {
@@ -179,9 +180,15 @@ namespace RobotComponents.ABB.Actions.Instructions
         /// </returns>
         public string ToRAPIDInstruction(Robot robot)
         {
+            if (!HelperMethods.IsValidRapidIdentifier(_name))
+            {
+                throw new InvalidOperationException(
+                    $"Cannot generate RAPID instruction: '{_name}' is not a valid RAPID identifier.");
+            }
+
             string result = $"SetDO ";
 
-            // Sync and delay cannot be combined. Sync is leading. 
+            // Sync and delay cannot be combined. Sync is leading.
             result += _sync ? "\\Sync, " : (_delay > 0 ? $"\\SDelay:={_delay:0.###}, " : "");
             result += $"{_name}, ";
             result += _value ? "1;" : "0;";
@@ -212,6 +219,7 @@ namespace RobotComponents.ABB.Actions.Instructions
             {
                 if (_name == null) { return false; }
                 if (_name == "") { return false; }
+                if (!HelperMethods.IsValidRapidIdentifier(_name)) { return false; }
                 return true;
             }
         }

--- a/RobotComponents.ABB/Actions/Instructions/SetDigitalOutput.cs
+++ b/RobotComponents.ABB/Actions/Instructions/SetDigitalOutput.cs
@@ -180,11 +180,7 @@ namespace RobotComponents.ABB.Actions.Instructions
         /// </returns>
         public string ToRAPIDInstruction(Robot robot)
         {
-            if (!HelperMethods.IsValidRapidIdentifier(_name))
-            {
-                throw new InvalidOperationException(
-                    $"Cannot generate RAPID instruction: '{_name}' is not a valid RAPID identifier.");
-            }
+            HelperMethods.ThrowIfInvalidRapidIdentifier(_name);
 
             string result = $"SetDO ";
 

--- a/RobotComponents.ABB/Actions/Instructions/SetGroupOutput.cs
+++ b/RobotComponents.ABB/Actions/Instructions/SetGroupOutput.cs
@@ -168,11 +168,7 @@ namespace RobotComponents.ABB.Actions.Instructions
         /// </returns>
         public string ToRAPIDInstruction(Robot robot)
         {
-            if (!HelperMethods.IsValidRapidIdentifier(_name))
-            {
-                throw new InvalidOperationException(
-                    $"Cannot generate RAPID instruction: '{_name}' is not a valid RAPID identifier.");
-            }
+            HelperMethods.ThrowIfInvalidRapidIdentifier(_name);
 
             return $"SetGO {_name}, {_value};";
         }

--- a/RobotComponents.ABB/Actions/Instructions/SetGroupOutput.cs
+++ b/RobotComponents.ABB/Actions/Instructions/SetGroupOutput.cs
@@ -16,6 +16,7 @@ using System.Runtime.Serialization;
 using System.Security.Permissions;
 // RobotComponents Libs
 using RobotComponents.ABB.Definitions;
+using RobotComponents.ABB.Utils;
 
 namespace RobotComponents.ABB.Actions.Instructions
 {
@@ -167,6 +168,12 @@ namespace RobotComponents.ABB.Actions.Instructions
         /// </returns>
         public string ToRAPIDInstruction(Robot robot)
         {
+            if (!HelperMethods.IsValidRapidIdentifier(_name))
+            {
+                throw new InvalidOperationException(
+                    $"Cannot generate RAPID instruction: '{_name}' is not a valid RAPID identifier.");
+            }
+
             return $"SetGO {_name}, {_value};";
         }
 
@@ -193,6 +200,7 @@ namespace RobotComponents.ABB.Actions.Instructions
             {
                 if (_name == null) { return false; }
                 if (_name == "") { return false; }
+                if (!HelperMethods.IsValidRapidIdentifier(_name)) { return false; }
                 return true;
             }
         }

--- a/RobotComponents.ABB/Actions/Instructions/WaitAI.cs
+++ b/RobotComponents.ABB/Actions/Instructions/WaitAI.cs
@@ -180,11 +180,7 @@ namespace RobotComponents.ABB.Actions.Instructions
         /// </returns>
         public string ToRAPIDInstruction(Robot robot)
         {
-            if (!HelperMethods.IsValidRapidIdentifier(_name))
-            {
-                throw new InvalidOperationException(
-                    $"Cannot generate RAPID instruction: '{_name}' is not a valid RAPID identifier.");
-            }
+            HelperMethods.ThrowIfInvalidRapidIdentifier(_name);
 
             return $"WaitAI {_name}, \\{Enum.GetName(typeof(InequalitySymbol), _inequalitySymbol)}, {_value}" +
                 $"{(_maxTime > 0 ? $"\\MaxTime:={_maxTime:0.###}" : "")};";

--- a/RobotComponents.ABB/Actions/Instructions/WaitAI.cs
+++ b/RobotComponents.ABB/Actions/Instructions/WaitAI.cs
@@ -16,6 +16,7 @@ using System.Security.Permissions;
 // RobotComponents Libs
 using RobotComponents.ABB.Enumerations;
 using RobotComponents.ABB.Definitions;
+using RobotComponents.ABB.Utils;
 
 namespace RobotComponents.ABB.Actions.Instructions
 {
@@ -179,6 +180,12 @@ namespace RobotComponents.ABB.Actions.Instructions
         /// </returns>
         public string ToRAPIDInstruction(Robot robot)
         {
+            if (!HelperMethods.IsValidRapidIdentifier(_name))
+            {
+                throw new InvalidOperationException(
+                    $"Cannot generate RAPID instruction: '{_name}' is not a valid RAPID identifier.");
+            }
+
             return $"WaitAI {_name}, \\{Enum.GetName(typeof(InequalitySymbol), _inequalitySymbol)}, {_value}" +
                 $"{(_maxTime > 0 ? $"\\MaxTime:={_maxTime:0.###}" : "")};";
         }
@@ -206,6 +213,7 @@ namespace RobotComponents.ABB.Actions.Instructions
             {
                 if (_name == null) { return false; }
                 if (_name == "") { return false; }
+                if (!HelperMethods.IsValidRapidIdentifier(_name)) { return false; }
                 return true;
             }
         }

--- a/RobotComponents.ABB/Actions/Instructions/WaitAO.cs
+++ b/RobotComponents.ABB/Actions/Instructions/WaitAO.cs
@@ -181,11 +181,7 @@ namespace RobotComponents.ABB.Actions.Instructions
         /// </returns>
         public string ToRAPIDInstruction(Robot robot)
         {
-            if (!HelperMethods.IsValidRapidIdentifier(_name))
-            {
-                throw new InvalidOperationException(
-                    $"Cannot generate RAPID instruction: '{_name}' is not a valid RAPID identifier.");
-            }
+            HelperMethods.ThrowIfInvalidRapidIdentifier(_name);
 
             return $"WaitAO {_name}, \\{Enum.GetName(typeof(InequalitySymbol), _inequalitySymbol)}, {_value}" +
                 $"{(_maxTime > 0 ? $"\\MaxTime:={_maxTime:0.###}" : "")};";

--- a/RobotComponents.ABB/Actions/Instructions/WaitAO.cs
+++ b/RobotComponents.ABB/Actions/Instructions/WaitAO.cs
@@ -17,6 +17,7 @@ using System.Security.Permissions;
 // RobotComponents Libs
 using RobotComponents.ABB.Enumerations;
 using RobotComponents.ABB.Definitions;
+using RobotComponents.ABB.Utils;
 
 namespace RobotComponents.ABB.Actions.Instructions
 {
@@ -180,6 +181,12 @@ namespace RobotComponents.ABB.Actions.Instructions
         /// </returns>
         public string ToRAPIDInstruction(Robot robot)
         {
+            if (!HelperMethods.IsValidRapidIdentifier(_name))
+            {
+                throw new InvalidOperationException(
+                    $"Cannot generate RAPID instruction: '{_name}' is not a valid RAPID identifier.");
+            }
+
             return $"WaitAO {_name}, \\{Enum.GetName(typeof(InequalitySymbol), _inequalitySymbol)}, {_value}" +
                 $"{(_maxTime > 0 ? $"\\MaxTime:={_maxTime:0.###}" : "")};";
         }
@@ -207,6 +214,7 @@ namespace RobotComponents.ABB.Actions.Instructions
             {
                 if (_name == null) { return false; }
                 if (_name == "") { return false; }
+                if (!HelperMethods.IsValidRapidIdentifier(_name)) { return false; }
                 return true;
             }
         }

--- a/RobotComponents.ABB/Actions/Instructions/WaitDI.cs
+++ b/RobotComponents.ABB/Actions/Instructions/WaitDI.cs
@@ -182,11 +182,7 @@ namespace RobotComponents.ABB.Actions.Instructions
         /// </returns>
         public string ToRAPIDInstruction(Robot robot)
         {
-            if (!HelperMethods.IsValidRapidIdentifier(_name))
-            {
-                throw new InvalidOperationException(
-                    $"Cannot generate RAPID instruction: '{_name}' is not a valid RAPID identifier.");
-            }
+            HelperMethods.ThrowIfInvalidRapidIdentifier(_name);
 
             if (_maxTime > 0)
             {

--- a/RobotComponents.ABB/Actions/Instructions/WaitDI.cs
+++ b/RobotComponents.ABB/Actions/Instructions/WaitDI.cs
@@ -18,6 +18,7 @@ using System.Runtime.Serialization;
 using System.Security.Permissions;
 // RobotComponents Libs
 using RobotComponents.ABB.Definitions;
+using RobotComponents.ABB.Utils;
 
 namespace RobotComponents.ABB.Actions.Instructions
 {
@@ -181,6 +182,12 @@ namespace RobotComponents.ABB.Actions.Instructions
         /// </returns>
         public string ToRAPIDInstruction(Robot robot)
         {
+            if (!HelperMethods.IsValidRapidIdentifier(_name))
+            {
+                throw new InvalidOperationException(
+                    $"Cannot generate RAPID instruction: '{_name}' is not a valid RAPID identifier.");
+            }
+
             if (_maxTime > 0)
             {
                 string result = $"WaitDI {_name}, {(_value ? 1 : 0)} ";
@@ -219,6 +226,7 @@ namespace RobotComponents.ABB.Actions.Instructions
             {
                 if (_name == null) { return false; }
                 if (_name == "") { return false; }
+                if (!HelperMethods.IsValidRapidIdentifier(_name)) { return false; }
                 return true;
             }
         }

--- a/RobotComponents.ABB/Actions/Instructions/WaitDO.cs
+++ b/RobotComponents.ABB/Actions/Instructions/WaitDO.cs
@@ -16,6 +16,7 @@ using System.Runtime.Serialization;
 using System.Security.Permissions;
 // RobotComponents Libs
 using RobotComponents.ABB.Definitions;
+using RobotComponents.ABB.Utils;
 
 namespace RobotComponents.ABB.Actions.Instructions
 {
@@ -179,6 +180,12 @@ namespace RobotComponents.ABB.Actions.Instructions
         /// </returns>
         public string ToRAPIDInstruction(Robot robot)
         {
+            if (!HelperMethods.IsValidRapidIdentifier(_name))
+            {
+                throw new InvalidOperationException(
+                    $"Cannot generate RAPID instruction: '{_name}' is not a valid RAPID identifier.");
+            }
+
             if (_maxTime > 0)
             {
                 string result = $"WaitDO {_name}, {(_value ? 1 : 0)} ";
@@ -217,6 +224,7 @@ namespace RobotComponents.ABB.Actions.Instructions
             {
                 if (_name == null) { return false; }
                 if (_name == "") { return false; }
+                if (!HelperMethods.IsValidRapidIdentifier(_name)) { return false; }
                 return true;
             }
         }

--- a/RobotComponents.ABB/Actions/Instructions/WaitDO.cs
+++ b/RobotComponents.ABB/Actions/Instructions/WaitDO.cs
@@ -180,11 +180,7 @@ namespace RobotComponents.ABB.Actions.Instructions
         /// </returns>
         public string ToRAPIDInstruction(Robot robot)
         {
-            if (!HelperMethods.IsValidRapidIdentifier(_name))
-            {
-                throw new InvalidOperationException(
-                    $"Cannot generate RAPID instruction: '{_name}' is not a valid RAPID identifier.");
-            }
+            HelperMethods.ThrowIfInvalidRapidIdentifier(_name);
 
             if (_maxTime > 0)
             {

--- a/RobotComponents.ABB/Actions/Instructions/WaitGI.cs
+++ b/RobotComponents.ABB/Actions/Instructions/WaitGI.cs
@@ -174,11 +174,7 @@ namespace RobotComponents.ABB.Actions.Instructions
         /// </returns>
         public string ToRAPIDInstruction(Robot robot)
         {
-            if (!HelperMethods.IsValidRapidIdentifier(_name))
-            {
-                throw new InvalidOperationException(
-                    $"Cannot generate RAPID instruction: '{_name}' is not a valid RAPID identifier.");
-            }
+            HelperMethods.ThrowIfInvalidRapidIdentifier(_name);
 
             if (_maxTime > 0)
             {

--- a/RobotComponents.ABB/Actions/Instructions/WaitGI.cs
+++ b/RobotComponents.ABB/Actions/Instructions/WaitGI.cs
@@ -16,6 +16,7 @@ using System.Runtime.Serialization;
 using System.Security.Permissions;
 // RobotComponents Libs
 using RobotComponents.ABB.Definitions;
+using RobotComponents.ABB.Utils;
 
 namespace RobotComponents.ABB.Actions.Instructions
 {
@@ -173,6 +174,12 @@ namespace RobotComponents.ABB.Actions.Instructions
         /// </returns>
         public string ToRAPIDInstruction(Robot robot)
         {
+            if (!HelperMethods.IsValidRapidIdentifier(_name))
+            {
+                throw new InvalidOperationException(
+                    $"Cannot generate RAPID instruction: '{_name}' is not a valid RAPID identifier.");
+            }
+
             if (_maxTime > 0)
             {
                 string result = $"WaitGI {_name}, {_value} ";
@@ -211,6 +218,7 @@ namespace RobotComponents.ABB.Actions.Instructions
             {
                 if (_name == null) { return false; }
                 if (_name == "") { return false; }
+                if (!HelperMethods.IsValidRapidIdentifier(_name)) { return false; }
                 return true;
             }
         }

--- a/RobotComponents.ABB/Actions/Instructions/WaitGO.cs
+++ b/RobotComponents.ABB/Actions/Instructions/WaitGO.cs
@@ -16,6 +16,7 @@ using System.Runtime.Serialization;
 using System.Security.Permissions;
 // RobotComponents Libs
 using RobotComponents.ABB.Definitions;
+using RobotComponents.ABB.Utils;
 
 namespace RobotComponents.ABB.Actions.Instructions
 {
@@ -173,6 +174,12 @@ namespace RobotComponents.ABB.Actions.Instructions
         /// </returns>
         public string ToRAPIDInstruction(Robot robot)
         {
+            if (!HelperMethods.IsValidRapidIdentifier(_name))
+            {
+                throw new InvalidOperationException(
+                    $"Cannot generate RAPID instruction: '{_name}' is not a valid RAPID identifier.");
+            }
+
             if (_maxTime > 0)
             {
                 string result = $"WaitGO {_name}, {_value} ";
@@ -211,6 +218,7 @@ namespace RobotComponents.ABB.Actions.Instructions
             {
                 if (_name == null) { return false; }
                 if (_name == "") { return false; }
+                if (!HelperMethods.IsValidRapidIdentifier(_name)) { return false; }
                 return true;
             }
         }

--- a/RobotComponents.ABB/Actions/Instructions/WaitGO.cs
+++ b/RobotComponents.ABB/Actions/Instructions/WaitGO.cs
@@ -174,11 +174,7 @@ namespace RobotComponents.ABB.Actions.Instructions
         /// </returns>
         public string ToRAPIDInstruction(Robot robot)
         {
-            if (!HelperMethods.IsValidRapidIdentifier(_name))
-            {
-                throw new InvalidOperationException(
-                    $"Cannot generate RAPID instruction: '{_name}' is not a valid RAPID identifier.");
-            }
+            HelperMethods.ThrowIfInvalidRapidIdentifier(_name);
 
             if (_maxTime > 0)
             {

--- a/RobotComponents.ABB/Utils/HelperMethods.cs
+++ b/RobotComponents.ABB/Utils/HelperMethods.cs
@@ -283,6 +283,22 @@ namespace RobotComponents.ABB.Utils
         }
 
         /// <summary>
+        /// Throws an <see cref="InvalidOperationException"/> if the given string is not a valid RAPID identifier.
+        /// </summary>
+        /// <param name="name"> The identifier to validate. </param>
+        /// <exception cref="InvalidOperationException">
+        /// <paramref name="name"/> is not a valid RAPID identifier.
+        /// </exception>
+        public static void ThrowIfInvalidRapidIdentifier(string name)
+        {
+            if (!IsValidRapidIdentifier(name))
+            {
+                throw new InvalidOperationException(
+                    $"Cannot generate RAPID instruction: '{name}' is not a valid RAPID identifier.");
+            }
+        }
+
+        /// <summary>
         /// Interpolates between two quaternions using spherical linear interpolation.
         /// </summary>
         /// <param name="quat1"> The first quaternion. </param>

--- a/RobotComponents.ABB/Utils/HelperMethods.cs
+++ b/RobotComponents.ABB/Utils/HelperMethods.cs
@@ -30,6 +30,7 @@ namespace RobotComponents.ABB.Utils
     {
         #region fields
         private static readonly Regex _rapidDataRegex = new Regex(@"[\s;:\[\]\(\){}]", RegexOptions.Compiled);
+        private static readonly Regex _rapidIdentifierRegex = new Regex(@"^[a-zA-Z_][a-zA-Z0-9_]{0,31}$", RegexOptions.Compiled);
         #endregion
 
         #region methods
@@ -261,6 +262,24 @@ namespace RobotComponents.ABB.Utils
             }
 
             return text.Substring(0, position) + replace + text.Substring(position + search.Length);
+        }
+
+        /// <summary>
+        /// Returns a value indicating whether the given string is a valid RAPID identifier.
+        /// </summary>
+        /// <remarks>
+        /// A valid RAPID identifier starts with a letter or underscore, contains only
+        /// letters, digits, and underscores, and is at most 32 characters long.
+        /// </remarks>
+        /// <param name="name"> The identifier to validate. </param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="name"/> is a valid RAPID identifier;
+        /// otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool IsValidRapidIdentifier(string name)
+        {
+            if (name == null) { return false; }
+            return _rapidIdentifierRegex.IsMatch(name);
         }
 
         /// <summary>

--- a/RobotComponents.Tests/Actions/PulseDigitalOutputTests.cs
+++ b/RobotComponents.Tests/Actions/PulseDigitalOutputTests.cs
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This file is part of Robot Components
+// Project: https://github.com/RobotComponents/RobotComponents
+//
+// For license details, see the LICENSE file in the project root.
+
+// System Libs
+using System;
+// Xunit Libs
+using Xunit;
+// Robot Components Libs
+using RobotComponents.ABB.Actions.Instructions;
+
+namespace RobotComponents.Tests.Actions
+{
+    public class PulseDigitalOutputTests
+    {
+        [Fact]
+        public void Basic_ProducesPulseDO()
+        {
+            PulseDigitalOutput pdo = new PulseDigitalOutput(false, 0.5, "signal");
+
+            Assert.Equal("PulseDO \\PLength:=.5, signal;", pdo.ToRAPIDInstruction(null));
+        }
+
+        [Fact]
+        public void WithHigh_IncludesHigh()
+        {
+            PulseDigitalOutput pdo = new PulseDigitalOutput(true, 0.5, "signal");
+
+            Assert.Equal("PulseDO \\High, \\PLength:=.5, signal;", pdo.ToRAPIDInstruction(null));
+        }
+
+        [Fact]
+        public void IsValid_TrueWithValidNameAndLength()
+        {
+            PulseDigitalOutput pdo = new PulseDigitalOutput(false, 0.2, "do_1");
+
+            Assert.True(pdo.IsValid);
+        }
+
+        [Fact]
+        public void IsValid_FalseWithInjectionPayload()
+        {
+            PulseDigitalOutput pdo = new PulseDigitalOutput(false, 0.2, "signal;\nMoveJ");
+
+            Assert.False(pdo.IsValid);
+        }
+
+        [Fact]
+        public void ToRAPIDInstruction_ThrowsOnInvalidName()
+        {
+            PulseDigitalOutput pdo = new PulseDigitalOutput(false, 0.2, "signal;inject");
+
+            Assert.Throws<InvalidOperationException>(() => pdo.ToRAPIDInstruction(null));
+        }
+    }
+}

--- a/RobotComponents.Tests/Actions/SetAnalogOutputTests.cs
+++ b/RobotComponents.Tests/Actions/SetAnalogOutputTests.cs
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This file is part of Robot Components
+// Project: https://github.com/RobotComponents/RobotComponents
+//
+// For license details, see the LICENSE file in the project root.
+
+// System Libs
+using System;
+// Xunit Libs
+using Xunit;
+// Robot Components Libs
+using RobotComponents.ABB.Actions.Instructions;
+
+namespace RobotComponents.Tests.Actions
+{
+    public class SetAnalogOutputTests
+    {
+        [Fact]
+        public void BasicValue_ProducesSetAO()
+        {
+            SetAnalogOutput sao = new SetAnalogOutput("signal", 5.5);
+
+            Assert.Equal("SetAO signal, 5.5;", sao.ToRAPIDInstruction(null));
+        }
+
+        [Fact]
+        public void IsValid_TrueWithValidName()
+        {
+            SetAnalogOutput sao = new SetAnalogOutput("ao_1", 0);
+
+            Assert.True(sao.IsValid);
+        }
+
+        [Fact]
+        public void IsValid_FalseWithInjectionPayload()
+        {
+            SetAnalogOutput sao = new SetAnalogOutput("signal, 1;\nSetAO other", 0);
+
+            Assert.False(sao.IsValid);
+        }
+
+        [Fact]
+        public void ToRAPIDInstruction_ThrowsOnInvalidName()
+        {
+            SetAnalogOutput sao = new SetAnalogOutput("signal;inject", 0);
+
+            Assert.Throws<InvalidOperationException>(() => sao.ToRAPIDInstruction(null));
+        }
+    }
+}

--- a/RobotComponents.Tests/Actions/SetDigitalOutputTests.cs
+++ b/RobotComponents.Tests/Actions/SetDigitalOutputTests.cs
@@ -4,6 +4,8 @@
 //
 // For license details, see the LICENSE file in the project root.
 
+// System Libs
+using System;
 // Xunit Libs
 using Xunit;
 // Robot Components Libs
@@ -90,6 +92,30 @@ namespace RobotComponents.Tests.Actions
             SetDigitalOutput sdo = new SetDigitalOutput("signal", true);
 
             Assert.Equal(string.Empty, sdo.ToRAPIDDeclaration(null));
+        }
+
+        [Fact]
+        public void IsValid_FalseWithInjectionPayload()
+        {
+            SetDigitalOutput sdo = new SetDigitalOutput("signal, 1;\nSetDO other", true);
+
+            Assert.False(sdo.IsValid);
+        }
+
+        [Fact]
+        public void IsValid_FalseWithNameStartingWithDigit()
+        {
+            SetDigitalOutput sdo = new SetDigitalOutput("1signal", true);
+
+            Assert.False(sdo.IsValid);
+        }
+
+        [Fact]
+        public void ToRAPIDInstruction_ThrowsOnInvalidName()
+        {
+            SetDigitalOutput sdo = new SetDigitalOutput("signal, 1;\nSetDO other", true);
+
+            Assert.Throws<InvalidOperationException>(() => sdo.ToRAPIDInstruction(null));
         }
     }
 }

--- a/RobotComponents.Tests/Actions/SetGroupOutputTests.cs
+++ b/RobotComponents.Tests/Actions/SetGroupOutputTests.cs
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This file is part of Robot Components
+// Project: https://github.com/RobotComponents/RobotComponents
+//
+// For license details, see the LICENSE file in the project root.
+
+// System Libs
+using System;
+// Xunit Libs
+using Xunit;
+// Robot Components Libs
+using RobotComponents.ABB.Actions.Instructions;
+
+namespace RobotComponents.Tests.Actions
+{
+    public class SetGroupOutputTests
+    {
+        [Fact]
+        public void BasicValue_ProducesSetGO()
+        {
+            SetGroupOutput sgo = new SetGroupOutput("group1", 3);
+
+            Assert.Equal("SetGO group1, 3;", sgo.ToRAPIDInstruction(null));
+        }
+
+        [Fact]
+        public void IsValid_TrueWithValidName()
+        {
+            SetGroupOutput sgo = new SetGroupOutput("go_1", 0);
+
+            Assert.True(sgo.IsValid);
+        }
+
+        [Fact]
+        public void IsValid_FalseWithInjectionPayload()
+        {
+            SetGroupOutput sgo = new SetGroupOutput("signal, 1;\nSetGO other", 0);
+
+            Assert.False(sgo.IsValid);
+        }
+
+        [Fact]
+        public void ToRAPIDInstruction_ThrowsOnInvalidName()
+        {
+            SetGroupOutput sgo = new SetGroupOutput("signal;inject", 0);
+
+            Assert.Throws<InvalidOperationException>(() => sgo.ToRAPIDInstruction(null));
+        }
+    }
+}

--- a/RobotComponents.Tests/Actions/WaitAnalogIOTests.cs
+++ b/RobotComponents.Tests/Actions/WaitAnalogIOTests.cs
@@ -4,6 +4,8 @@
 //
 // For license details, see the LICENSE file in the project root.
 
+// System Libs
+using System;
 // Xunit Libs
 using Xunit;
 // Robot Components Libs
@@ -47,6 +49,22 @@ namespace RobotComponents.Tests.Actions
 
             Assert.True(wai.IsValid);
         }
+
+        [Fact]
+        public void IsValid_FalseWithInjectionPayload()
+        {
+            WaitAI wai = new WaitAI("ai1, \\LT, 0;\nMoveJ target", 5.0, InequalitySymbol.LT);
+
+            Assert.False(wai.IsValid);
+        }
+
+        [Fact]
+        public void ToRAPIDInstruction_ThrowsOnInvalidName()
+        {
+            WaitAI wai = new WaitAI("ai1;inject", 5.0, InequalitySymbol.LT);
+
+            Assert.Throws<InvalidOperationException>(() => wai.ToRAPIDInstruction(null));
+        }
     }
 
     public class WaitAOTests
@@ -67,6 +85,22 @@ namespace RobotComponents.Tests.Actions
             string result = wao.ToRAPIDInstruction(null);
 
             Assert.Contains("\\MaxTime:=10", result);
+        }
+
+        [Fact]
+        public void IsValid_FalseWithInjectionPayload()
+        {
+            WaitAO wao = new WaitAO("ao1, \\LT, 0;\nMoveJ target", 5.0, InequalitySymbol.LT);
+
+            Assert.False(wao.IsValid);
+        }
+
+        [Fact]
+        public void ToRAPIDInstruction_ThrowsOnInvalidName()
+        {
+            WaitAO wao = new WaitAO("ao1;inject", 5.0, InequalitySymbol.LT);
+
+            Assert.Throws<InvalidOperationException>(() => wao.ToRAPIDInstruction(null));
         }
     }
 }

--- a/RobotComponents.Tests/Actions/WaitDigitalIOTests.cs
+++ b/RobotComponents.Tests/Actions/WaitDigitalIOTests.cs
@@ -4,6 +4,8 @@
 //
 // For license details, see the LICENSE file in the project root.
 
+// System Libs
+using System;
 // Xunit Libs
 using Xunit;
 // Robot Components Libs
@@ -66,6 +68,22 @@ namespace RobotComponents.Tests.Actions
 
             Assert.False(wdi.IsValid);
         }
+
+        [Fact]
+        public void IsValid_FalseWithInjectionPayload()
+        {
+            WaitDI wdi = new WaitDI("di1, 1;\nMoveJ target", true);
+
+            Assert.False(wdi.IsValid);
+        }
+
+        [Fact]
+        public void ToRAPIDInstruction_ThrowsOnInvalidName()
+        {
+            WaitDI wdi = new WaitDI("di1;inject", true);
+
+            Assert.Throws<InvalidOperationException>(() => wdi.ToRAPIDInstruction(null));
+        }
     }
 
     public class WaitDOTests
@@ -88,6 +106,22 @@ namespace RobotComponents.Tests.Actions
             Assert.Contains("WaitDO", result);
             Assert.Contains("\\MaxTime:=5", result);
             Assert.Contains("\\TimeFlag:=TRUE", result);
+        }
+
+        [Fact]
+        public void IsValid_FalseWithInjectionPayload()
+        {
+            WaitDO wdo = new WaitDO("do1, 1;\nMoveJ target", true);
+
+            Assert.False(wdo.IsValid);
+        }
+
+        [Fact]
+        public void ToRAPIDInstruction_ThrowsOnInvalidName()
+        {
+            WaitDO wdo = new WaitDO("do1;inject", true);
+
+            Assert.Throws<InvalidOperationException>(() => wdo.ToRAPIDInstruction(null));
         }
     }
 }

--- a/RobotComponents.Tests/Actions/WaitGroupIOTests.cs
+++ b/RobotComponents.Tests/Actions/WaitGroupIOTests.cs
@@ -4,6 +4,8 @@
 //
 // For license details, see the LICENSE file in the project root.
 
+// System Libs
+using System;
 // Xunit Libs
 using Xunit;
 // Robot Components Libs
@@ -38,6 +40,22 @@ namespace RobotComponents.Tests.Actions
 
             Assert.True(wgi.IsValid);
         }
+
+        [Fact]
+        public void IsValid_FalseWithInjectionPayload()
+        {
+            WaitGI wgi = new WaitGI("gi1, 0;\nMoveJ target", 42);
+
+            Assert.False(wgi.IsValid);
+        }
+
+        [Fact]
+        public void ToRAPIDInstruction_ThrowsOnInvalidName()
+        {
+            WaitGI wgi = new WaitGI("gi1;inject", 42);
+
+            Assert.Throws<InvalidOperationException>(() => wgi.ToRAPIDInstruction(null));
+        }
     }
 
     public class WaitGOTests
@@ -58,6 +76,22 @@ namespace RobotComponents.Tests.Actions
             string result = wgo.ToRAPIDInstruction(null);
 
             Assert.Contains("\\MaxTime:=5", result);
+        }
+
+        [Fact]
+        public void IsValid_FalseWithInjectionPayload()
+        {
+            WaitGO wgo = new WaitGO("go1, 0;\nMoveJ target", 42);
+
+            Assert.False(wgo.IsValid);
+        }
+
+        [Fact]
+        public void ToRAPIDInstruction_ThrowsOnInvalidName()
+        {
+            WaitGO wgo = new WaitGO("go1;inject", 42);
+
+            Assert.Throws<InvalidOperationException>(() => wgo.ToRAPIDInstruction(null));
         }
     }
 }

--- a/RobotComponents.Tests/HelperMethodTests.cs
+++ b/RobotComponents.Tests/HelperMethodTests.cs
@@ -464,6 +464,48 @@ namespace RobotComponents.Tests
         }
         #endregion
 
+        #region IsValidRapidIdentifier
+        [Theory]
+        [InlineData("signal", true)]
+        [InlineData("_mySignal", true)]
+        [InlineData("di1", true)]
+        [InlineData("A", true)]
+        [InlineData("a_b_c_123", true)]
+        [InlineData(null, false)]
+        [InlineData("", false)]
+        [InlineData("1signal", false)]
+        [InlineData("sig nal", false)]
+        [InlineData("sig;nal", false)]
+        [InlineData("sig,nal", false)]
+        [InlineData("sig\nnal", false)]
+        [InlineData("sig\"nal", false)]
+        public void IsValidRapidIdentifier_ClassifiesCorrectly(string name, bool expected)
+        {
+            Assert.Equal(expected, HelperMethods.IsValidRapidIdentifier(name));
+        }
+
+        [Fact]
+        public void IsValidRapidIdentifier_Exactly32Chars_ReturnsTrue()
+        {
+            string name = new string('a', 32);
+            Assert.True(HelperMethods.IsValidRapidIdentifier(name));
+        }
+
+        [Fact]
+        public void IsValidRapidIdentifier_33Chars_ReturnsFalse()
+        {
+            string name = new string('a', 33);
+            Assert.False(HelperMethods.IsValidRapidIdentifier(name));
+        }
+
+        [Fact]
+        public void IsValidRapidIdentifier_InjectionPayload_ReturnsFalse()
+        {
+            string payload = "signal, 1;\nSetDO other, 1;";
+            Assert.False(HelperMethods.IsValidRapidIdentifier(payload));
+        }
+        #endregion
+
         #region test helpers
         /// <summary>
         /// Minimal IDeclaration stub for testing SetRapidDataFromString.

--- a/RobotComponents.Tests/HelperMethodTests.cs
+++ b/RobotComponents.Tests/HelperMethodTests.cs
@@ -504,6 +504,27 @@ namespace RobotComponents.Tests
             string payload = "signal, 1;\nSetDO other, 1;";
             Assert.False(HelperMethods.IsValidRapidIdentifier(payload));
         }
+
+        [Fact]
+        public void ThrowIfInvalidRapidIdentifier_ValidName_DoesNotThrow()
+        {
+            HelperMethods.ThrowIfInvalidRapidIdentifier("signal");
+        }
+
+        [Fact]
+        public void ThrowIfInvalidRapidIdentifier_InvalidName_ThrowsInvalidOperationException()
+        {
+            var ex = Assert.Throws<InvalidOperationException>(
+                () => HelperMethods.ThrowIfInvalidRapidIdentifier("sig;nal"));
+            Assert.Contains("sig;nal", ex.Message);
+        }
+
+        [Fact]
+        public void ThrowIfInvalidRapidIdentifier_Null_ThrowsInvalidOperationException()
+        {
+            Assert.Throws<InvalidOperationException>(
+                () => HelperMethods.ThrowIfInvalidRapidIdentifier(null));
+        }
         #endregion
 
         #region test helpers


### PR DESCRIPTION
## Summary

- Add shared `IsValidRapidIdentifier` validator to core `HelperMethods` using compiled regex `^[a-zA-Z_][a-zA-Z0-9_]{0,31}$`
- Extend `IsValid` and guard `ToRAPIDInstruction` with `InvalidOperationException` in all 10 signal instruction classes: `SetDigitalOutput`, `SetAnalogOutput`, `SetGroupOutput`, `PulseDigitalOutput`, `WaitDI`, `WaitDO`, `WaitAI`, `WaitAO`, `WaitGI`, `WaitGO`
- Add injection-rejection tests for each class plus comprehensive unit tests for the validator itself

Closes #34

## Details

Previously, signal names were embedded verbatim into RAPID output strings with no validation beyond null/empty. A crafted name like `signal, 1;\nMoveJ target` would inject arbitrary RAPID instructions. The `RAPIDGenerator.CreateModule` loop calls `ToRAPIDGenerator` without checking `IsValid`, so invalid names reached the output unconditionally.

The fix enforces validation at the core library level (`RobotComponents.ABB`) so both Grasshopper component users and programmatic API callers are protected. The existing GH-layer warnings remain unchanged as user-facing feedback.

## Breaking change note

The core validator uses a strict RAPID identifier regex that does **not** allow colons. The GH-layer regex (`[^A-Za-z0-9:_]`) intentionally permits colons because some ABB system-level signal names use them (e.g. `System:di1`). If any signal names with colons are in use, they will now be rejected by `IsValid` and `ToRAPIDInstruction` at the core level. If this becomes an issue, the regex can be extended to allow colons in a follow-up.

## Test plan

- [x] Verify new `IsValidRapidIdentifier` tests pass (no Rhino dependency)
- [x] Verify injection-rejection tests pass for all 10 signal classes
- [x] Verify existing tests still pass (all use valid names like `"signal"`, `"di1"`)
- [x] CI green on Windows .NET Framework 4.8

🤖 Generated with [Claude Code](https://claude.com/claude-code)