### PR TITLE
Fix command injection via RhinoApp.RunScript (#35)

### DIFF
--- a/RobotComponents.ABB.Presets/Utils/HelperMethods.cs
+++ b/RobotComponents.ABB.Presets/Utils/HelperMethods.cs
@@ -11,6 +11,7 @@
 
 // System Libs
 using System;
+using System.IO;
 using System.Text.RegularExpressions;
 // Robot Components Libs
 using RobotComponents.ABB.Presets.Enumerations;
@@ -83,6 +84,51 @@ namespace RobotComponents.ABB.Presets.Utils
             className = className.Replace(".", "");
 
             return className;
+        }
+        /// <summary>
+        /// Checks whether a file path is safe to interpolate into a RhinoApp.RunScript command.
+        /// </summary>
+        /// <remarks>
+        /// Rejects paths that contain double quotes (which would break out of the quoted argument
+        /// in a RunScript command string) or characters from <see cref="Path.GetInvalidPathChars"/>.
+        /// </remarks>
+        /// <param name="filePath"> The file path to validate. </param>
+        /// <returns> True if the path is safe; false otherwise. </returns>
+        internal static bool IsSafeFilePath(string filePath)
+        {
+            if (string.IsNullOrEmpty(filePath))
+            {
+                return false;
+            }
+
+            if (filePath.IndexOf('"') >= 0)
+            {
+                return false;
+            }
+
+            char[] invalidChars = Path.GetInvalidPathChars();
+
+            if (filePath.IndexOfAny(invalidChars) >= 0)
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Throws an <see cref="ArgumentException"/> if the file path is not safe for use
+        /// in a RhinoApp.RunScript command.
+        /// </summary>
+        /// <param name="filePath"> The file path to validate. </param>
+        /// <exception cref="ArgumentException"> Thrown when the path contains unsafe characters. </exception>
+        internal static void ThrowIfUnsafeFilePath(string filePath)
+        {
+            if (!IsSafeFilePath(filePath))
+            {
+                throw new ArgumentException(
+                    $"The file path '{filePath}' contains characters that are unsafe for script execution.");
+            }
         }
         #endregion
 

--- a/RobotComponents.ABB.Presets/Utils/HelperMethods.cs
+++ b/RobotComponents.ABB.Presets/Utils/HelperMethods.cs
@@ -85,6 +85,7 @@ namespace RobotComponents.ABB.Presets.Utils
 
             return className;
         }
+
         /// <summary>
         /// Checks whether a file path is safe to interpolate into a RhinoApp.RunScript command.
         /// </summary>
@@ -127,7 +128,7 @@ namespace RobotComponents.ABB.Presets.Utils
             if (!IsSafeFilePath(filePath))
             {
                 throw new ArgumentException(
-                    $"The file path '{filePath}' contains characters that are unsafe for script execution.");
+                    "The file path contains characters that are unsafe for script execution.");
             }
         }
         #endregion

--- a/RobotComponents.ABB.Presets/Utils/Preperation.cs
+++ b/RobotComponents.ABB.Presets/Utils/Preperation.cs
@@ -289,6 +289,9 @@ namespace RobotComponents.ABB.Presets.Utils
                     before.Add(existingObjects[j].Id);
                 }
 
+                // Validate file path to prevent command injection (OWASP A03, issue #35)
+                HelperMethods.ThrowIfUnsafeFilePath(filePath);
+
                 // Import STEP file
                 string command = "-_Import \"" + filePath + "\" _Enter";
                 RhinoApp.RunScript(command, false);

--- a/RobotComponents.ABB.Presets/Utils/Preperation.cs
+++ b/RobotComponents.ABB.Presets/Utils/Preperation.cs
@@ -328,6 +328,7 @@ namespace RobotComponents.ABB.Presets.Utils
             }
 
             // Step 3: Purge unused definitions (run multiple times to be thorough)
+            // Hardcoded commands — no user input interpolated, safe from injection.
             RhinoApp.RunScript("_-Purge _All _Yes _Enter", false);
             RhinoApp.RunScript("_-Purge _All _Yes _Enter", false);
             RhinoApp.RunScript("_-Purge _All _Yes _Enter", false);

--- a/RobotComponents.Tests/HelperMethodTests.cs
+++ b/RobotComponents.Tests/HelperMethodTests.cs
@@ -16,6 +16,7 @@ using RobotComponents.ABB.Actions.Declarations;
 using RobotComponents.ABB.Definitions;
 using RobotComponents.ABB.Enumerations;
 using RobotComponents.ABB.Utils;
+using PresetHelpers = RobotComponents.ABB.Presets.Utils.HelperMethods;
 
 namespace RobotComponents.Tests
 {
@@ -524,6 +525,56 @@ namespace RobotComponents.Tests
         {
             Assert.Throws<InvalidOperationException>(
                 () => HelperMethods.ThrowIfInvalidRapidIdentifier(null));
+        }
+        #endregion
+
+        #region IsSafeFilePath
+        [Theory]
+        [InlineData(@"C:\Models\robot.step", true)]
+        [InlineData(@"C:\My Models\robot.stp", true)]
+        [InlineData(@"/home/user/models/robot.step", true)]
+        [InlineData(@"robot.step", true)]
+        [InlineData(null, false)]
+        [InlineData("", false)]
+        public void IsSafeFilePath_ClassifiesCorrectly(string path, bool expected)
+        {
+            Assert.Equal(expected, PresetHelpers.IsSafeFilePath(path));
+        }
+
+        [Fact]
+        public void IsSafeFilePath_PathWithQuotes_ReturnsFalse()
+        {
+            string path = "robot\".step";
+            Assert.False(PresetHelpers.IsSafeFilePath(path));
+        }
+
+        [Fact]
+        public void IsSafeFilePath_InjectionPayload_ReturnsFalse()
+        {
+            // Exact attack scenario from issue #35
+            string payload = "file.step\" _Enter -_RunPythonScript \"C:\\malicious.py";
+            Assert.False(PresetHelpers.IsSafeFilePath(payload));
+        }
+
+        [Fact]
+        public void ThrowIfUnsafeFilePath_ValidPath_DoesNotThrow()
+        {
+            PresetHelpers.ThrowIfUnsafeFilePath(@"C:\Models\robot.step");
+        }
+
+        [Fact]
+        public void ThrowIfUnsafeFilePath_PathWithQuotes_ThrowsArgumentException()
+        {
+            var ex = Assert.Throws<ArgumentException>(
+                () => PresetHelpers.ThrowIfUnsafeFilePath("robot\".step"));
+            Assert.Contains("unsafe", ex.Message);
+        }
+
+        [Fact]
+        public void ThrowIfUnsafeFilePath_Null_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(
+                () => PresetHelpers.ThrowIfUnsafeFilePath(null));
         }
         #endregion
 


### PR DESCRIPTION
## Summary
- Adds `IsSafeFilePath` / `ThrowIfUnsafeFilePath` validation to reject file paths containing double quotes or invalid path characters before they are interpolated into `RhinoApp.RunScript` command strings
- Calls the validator in `Preperation.ImportStepAndOrganizeMulti` before the `RunScript` import call
- Adds 11 unit tests covering valid paths, the exact injection payload from the issue, null/empty inputs, and exception behavior

Fixes #35

## Test plan
- [x] `IsSafeFilePath` returns `true` for normal Windows and Unix STEP file paths
- [x] `IsSafeFilePath` returns `false` for paths containing `"` (the escape vector)
- [x] `IsSafeFilePath` returns `false` for the exact attack payload from the issue
- [x] `ThrowIfUnsafeFilePath` throws `ArgumentException` for unsafe paths
- [x] Build passes with 0 errors
- [x] All 11 new tests pass