### PR TITLE
Fix path traversal in Controller module name handling

### DIFF
--- a/RobotComponents.ABB.Controllers/Controller.cs
+++ b/RobotComponents.ABB.Controllers/Controller.cs
@@ -1361,10 +1361,20 @@ namespace RobotComponents.ABB.Controllers
                 Log(status);
                 string moduleName = module[0].Substring(7).Trim();
                 moduleName = moduleName.Split(' ')[0];
+
+                // Validate module name to prevent path traversal (OWASP A03, issue #36)
+                if (!HelperMethods.IsValidRapidIdentifier(moduleName))
+                {
+                    status = "Could not upload the module: The module name is not a valid RAPID identifier.";
+                    Log(status);
+                    return false;
+                }
+
                 moduleName += ".MOD";
                 status = $"Module name retreived: {moduleName}";
 
                 string filePathLocal = Path.Combine(_localAdditionalDirectory, moduleName);
+                HelperMethods.ThrowIfPathEscapesDirectory(_localAdditionalDirectory, filePathLocal);
                 remotefilePaths.Add(Path.Combine(_remoteAdditionalDirectory, moduleName));
 
                 try
@@ -1557,10 +1567,20 @@ namespace RobotComponents.ABB.Controllers
             Log(status);
             string moduleName = module[0].Substring(7).Trim();
             moduleName = moduleName.Split(' ')[0];
+
+            // Validate module name to prevent path traversal (OWASP A03, issue #36)
+            if (!HelperMethods.IsValidRapidIdentifier(moduleName))
+            {
+                status = "Could not upload the module: The module name is not a valid RAPID identifier.";
+                Log(status);
+                return false;
+            }
+
             moduleName += ".SYS";
             status = $"Module name retreived: {moduleName}";
 
             string filePathLocal = Path.Combine(_localSystemDirectory, moduleName);
+            HelperMethods.ThrowIfPathEscapesDirectory(_localSystemDirectory, filePathLocal);
 
             try
             {

--- a/RobotComponents.ABB.Controllers/Controller.cs
+++ b/RobotComponents.ABB.Controllers/Controller.cs
@@ -1120,6 +1120,15 @@ namespace RobotComponents.ABB.Controllers
             Log(status);
             moduleName = module[0].Substring(7).Trim();
             moduleName = moduleName.Split(' ')[0];
+
+            // Validate module name to prevent path traversal (OWASP A03, issue #36)
+            if (!HelperMethods.IsValidRapidIdentifier(moduleName))
+            {
+                status = "Could not upload the module: The module name is not a valid RAPID identifier.";
+                Log(status);
+                return false;
+            }
+
             moduleName += ".MOD";
 
             status = $"Module name retreived: {moduleName}";
@@ -1159,7 +1168,8 @@ namespace RobotComponents.ABB.Controllers
             }
 
             string filePathLocal = Path.Combine(_localDirectory, moduleName);
-            
+            HelperMethods.ThrowIfPathEscapesDirectory(_localDirectory, filePathLocal);
+
             try
             {
                 using (StreamWriter writer = new StreamWriter(filePathLocal, false))

--- a/RobotComponents.ABB.Controllers/Controller.cs
+++ b/RobotComponents.ABB.Controllers/Controller.cs
@@ -1168,7 +1168,13 @@ namespace RobotComponents.ABB.Controllers
             }
 
             string filePathLocal = Path.Combine(_localDirectory, moduleName);
-            HelperMethods.ThrowIfPathEscapesDirectory(_localDirectory, filePathLocal);
+
+            if (!HelperMethods.IsPathWithinDirectory(_localDirectory, filePathLocal))
+            {
+                status = "Could not upload the module: The resolved file path escapes the target directory.";
+                Log(status);
+                return false;
+            }
 
             try
             {
@@ -1374,7 +1380,14 @@ namespace RobotComponents.ABB.Controllers
                 status = $"Module name retreived: {moduleName}";
 
                 string filePathLocal = Path.Combine(_localAdditionalDirectory, moduleName);
-                HelperMethods.ThrowIfPathEscapesDirectory(_localAdditionalDirectory, filePathLocal);
+
+                if (!HelperMethods.IsPathWithinDirectory(_localAdditionalDirectory, filePathLocal))
+                {
+                    status = "Could not upload the module: The resolved file path escapes the target directory.";
+                    Log(status);
+                    return false;
+                }
+
                 remotefilePaths.Add(Path.Combine(_remoteAdditionalDirectory, moduleName));
 
                 try
@@ -1580,7 +1593,13 @@ namespace RobotComponents.ABB.Controllers
             status = $"Module name retreived: {moduleName}";
 
             string filePathLocal = Path.Combine(_localSystemDirectory, moduleName);
-            HelperMethods.ThrowIfPathEscapesDirectory(_localSystemDirectory, filePathLocal);
+
+            if (!HelperMethods.IsPathWithinDirectory(_localSystemDirectory, filePathLocal))
+            {
+                status = "Could not upload the module: The resolved file path escapes the target directory.";
+                Log(status);
+                return false;
+            }
 
             try
             {

--- a/RobotComponents.ABB.Controllers/Controller.cs
+++ b/RobotComponents.ABB.Controllers/Controller.cs
@@ -1237,6 +1237,13 @@ namespace RobotComponents.ABB.Controllers
                     // Load the new program from the drive
                     string filePathRemote = Path.Combine(_remoteDirectory, moduleName);
 
+                    if (!HelperMethods.IsPathWithinDirectory(_remoteDirectory, filePathRemote))
+                    {
+                        status = "Could not upload the module: The resolved remote file path escapes the target directory.";
+                        Log(status);
+                        return false;
+                    }
+
                     task.LoadModuleFromFile(filePathRemote, RapidDomainNS.RapidLoadMode.Replace);
 
                     status = "Loaded the module from the filesystem of the controller to the controller task.";
@@ -1388,7 +1395,16 @@ namespace RobotComponents.ABB.Controllers
                     return false;
                 }
 
-                remotefilePaths.Add(Path.Combine(_remoteAdditionalDirectory, moduleName));
+                string remoteFilePath = Path.Combine(_remoteAdditionalDirectory, moduleName);
+
+                if (!HelperMethods.IsPathWithinDirectory(_remoteAdditionalDirectory, remoteFilePath))
+                {
+                    status = "Could not upload the module: The resolved remote file path escapes the target directory.";
+                    Log(status);
+                    return false;
+                }
+
+                remotefilePaths.Add(remoteFilePath);
 
                 try
                 {

--- a/RobotComponents.ABB/Utils/HelperMethods.cs
+++ b/RobotComponents.ABB/Utils/HelperMethods.cs
@@ -300,7 +300,7 @@ namespace RobotComponents.ABB.Utils
         }
 
         /// <summary>
-        /// Throws an <see cref="ArgumentException"/> if the resolved file path escapes
+        /// Returns a value indicating whether the resolved file path stays within
         /// the specified base directory.
         /// </summary>
         /// <remarks>
@@ -311,11 +311,17 @@ namespace RobotComponents.ABB.Utils
         /// </remarks>
         /// <param name="baseDirectory"> The trusted base directory. </param>
         /// <param name="combinedPath"> The combined file path to validate. </param>
-        /// <exception cref="ArgumentException">
-        /// The resolved path is outside the base directory.
-        /// </exception>
-        public static void ThrowIfPathEscapesDirectory(string baseDirectory, string combinedPath)
+        /// <returns>
+        /// <see langword="true"/> if the resolved path is within the base directory;
+        /// otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool IsPathWithinDirectory(string baseDirectory, string combinedPath)
         {
+            if (baseDirectory == null || combinedPath == null)
+            {
+                return false;
+            }
+
             string fullBase = Path.GetFullPath(baseDirectory);
 
             if (!fullBase.EndsWith(Path.DirectorySeparatorChar.ToString()))
@@ -325,7 +331,21 @@ namespace RobotComponents.ABB.Utils
 
             string fullPath = Path.GetFullPath(combinedPath);
 
-            if (!fullPath.StartsWith(fullBase, StringComparison.OrdinalIgnoreCase))
+            return fullPath.StartsWith(fullBase, StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Throws an <see cref="ArgumentException"/> if the resolved file path escapes
+        /// the specified base directory.
+        /// </summary>
+        /// <param name="baseDirectory"> The trusted base directory. </param>
+        /// <param name="combinedPath"> The combined file path to validate. </param>
+        /// <exception cref="ArgumentException">
+        /// The resolved path is outside the base directory.
+        /// </exception>
+        public static void ThrowIfPathEscapesDirectory(string baseDirectory, string combinedPath)
+        {
+            if (!IsPathWithinDirectory(baseDirectory, combinedPath))
             {
                 throw new ArgumentException(
                     "The resolved file path escapes the target directory.");

--- a/RobotComponents.ABB/Utils/HelperMethods.cs
+++ b/RobotComponents.ABB/Utils/HelperMethods.cs
@@ -14,6 +14,7 @@
 
 // System Libs
 using System;
+using System.IO;
 using System.Text.RegularExpressions;
 // Rhino Libs
 using Rhino.Geometry;
@@ -295,6 +296,39 @@ namespace RobotComponents.ABB.Utils
             {
                 throw new InvalidOperationException(
                     $"Cannot generate RAPID instruction: '{name}' is not a valid RAPID identifier.");
+            }
+        }
+
+        /// <summary>
+        /// Throws an <see cref="ArgumentException"/> if the resolved file path escapes
+        /// the specified base directory.
+        /// </summary>
+        /// <remarks>
+        /// Resolves both paths via <see cref="Path.GetFullPath(string)"/> and verifies
+        /// that <paramref name="combinedPath"/> starts with <paramref name="baseDirectory"/>.
+        /// This prevents path traversal attacks where directory components like ".." could
+        /// cause file operations outside the intended directory.
+        /// </remarks>
+        /// <param name="baseDirectory"> The trusted base directory. </param>
+        /// <param name="combinedPath"> The combined file path to validate. </param>
+        /// <exception cref="ArgumentException">
+        /// The resolved path is outside the base directory.
+        /// </exception>
+        public static void ThrowIfPathEscapesDirectory(string baseDirectory, string combinedPath)
+        {
+            string fullBase = Path.GetFullPath(baseDirectory);
+
+            if (!fullBase.EndsWith(Path.DirectorySeparatorChar.ToString()))
+            {
+                fullBase += Path.DirectorySeparatorChar;
+            }
+
+            string fullPath = Path.GetFullPath(combinedPath);
+
+            if (!fullPath.StartsWith(fullBase, StringComparison.OrdinalIgnoreCase))
+            {
+                throw new ArgumentException(
+                    "The resolved file path escapes the target directory.");
             }
         }
 

--- a/RobotComponents.Tests/HelperMethodTests.cs
+++ b/RobotComponents.Tests/HelperMethodTests.cs
@@ -579,7 +579,46 @@ namespace RobotComponents.Tests
         }
         #endregion
 
-        #region ThrowIfPathEscapesDirectory
+        #region IsPathWithinDirectory / ThrowIfPathEscapesDirectory
+        [Fact]
+        public void IsPathWithinDirectory_SafePath_ReturnsTrue()
+        {
+            string baseDir = Path.Combine(Path.GetTempPath(), "TestBase");
+            string combined = Path.Combine(baseDir, "Module.MOD");
+
+            Assert.True(HelperMethods.IsPathWithinDirectory(baseDir, combined));
+        }
+
+        [Fact]
+        public void IsPathWithinDirectory_TraversalPayload_ReturnsFalse()
+        {
+            string baseDir = Path.Combine(Path.GetTempPath(), "TestBase");
+            string combined = Path.Combine(baseDir, "..", "..", "malicious.MOD");
+
+            Assert.False(HelperMethods.IsPathWithinDirectory(baseDir, combined));
+        }
+
+        [Fact]
+        public void IsPathWithinDirectory_AbsolutePathOutside_ReturnsFalse()
+        {
+            string baseDir = Path.Combine(Path.GetTempPath(), "TestBase");
+            string outside = Path.Combine(Path.GetTempPath(), "Other", "malicious.MOD");
+
+            Assert.False(HelperMethods.IsPathWithinDirectory(baseDir, outside));
+        }
+
+        [Fact]
+        public void IsPathWithinDirectory_NullBase_ReturnsFalse()
+        {
+            Assert.False(HelperMethods.IsPathWithinDirectory(null, "/tmp/file.MOD"));
+        }
+
+        [Fact]
+        public void IsPathWithinDirectory_NullPath_ReturnsFalse()
+        {
+            Assert.False(HelperMethods.IsPathWithinDirectory("/tmp", null));
+        }
+
         [Fact]
         public void ThrowIfPathEscapesDirectory_SafePath_DoesNotThrow()
         {

--- a/RobotComponents.Tests/HelperMethodTests.cs
+++ b/RobotComponents.Tests/HelperMethodTests.cs
@@ -6,6 +6,7 @@
 
 // System Libs
 using System;
+using System.IO;
 // Rhino Libs
 using Rhino.Geometry;
 // Xunit Libs
@@ -575,6 +576,60 @@ namespace RobotComponents.Tests
         {
             Assert.Throws<ArgumentException>(
                 () => PresetHelpers.ThrowIfUnsafeFilePath(null));
+        }
+        #endregion
+
+        #region ThrowIfPathEscapesDirectory
+        [Fact]
+        public void ThrowIfPathEscapesDirectory_SafePath_DoesNotThrow()
+        {
+            string baseDir = Path.Combine(Path.GetTempPath(), "TestBase");
+            string combined = Path.Combine(baseDir, "Module.MOD");
+
+            HelperMethods.ThrowIfPathEscapesDirectory(baseDir, combined);
+        }
+
+        [Fact]
+        public void ThrowIfPathEscapesDirectory_TraversalPayload_ThrowsArgumentException()
+        {
+            string baseDir = Path.Combine(Path.GetTempPath(), "TestBase");
+            string combined = Path.Combine(baseDir, "..", "..", "malicious.MOD");
+
+            Assert.Throws<ArgumentException>(
+                () => HelperMethods.ThrowIfPathEscapesDirectory(baseDir, combined));
+        }
+
+        [Fact]
+        public void ThrowIfPathEscapesDirectory_AbsolutePathOutside_ThrowsArgumentException()
+        {
+            string baseDir = Path.Combine(Path.GetTempPath(), "TestBase");
+            string outside = Path.Combine(Path.GetTempPath(), "Other", "malicious.MOD");
+
+            Assert.Throws<ArgumentException>(
+                () => HelperMethods.ThrowIfPathEscapesDirectory(baseDir, outside));
+        }
+        #endregion
+
+        #region Module name path traversal (issue #36)
+        [Theory]
+        [InlineData("../../../test")]
+        [InlineData("..\\..\\test")]
+        [InlineData("test/../../etc")]
+        [InlineData("test\\..\\..\\etc")]
+        [InlineData(".")]
+        [InlineData("..")]
+        public void IsValidRapidIdentifier_PathTraversalPayload_ReturnsFalse(string name)
+        {
+            Assert.False(HelperMethods.IsValidRapidIdentifier(name));
+        }
+
+        [Theory]
+        [InlineData("MainModule")]
+        [InlineData("T_ROB1")]
+        [InlineData("my_module_01")]
+        public void IsValidRapidIdentifier_ValidModuleName_ReturnsTrue(string name)
+        {
+            Assert.True(HelperMethods.IsValidRapidIdentifier(name));
         }
         #endregion
 


### PR DESCRIPTION
## Summary
- Validate extracted module names against RAPID identifier rules (`^[a-zA-Z_][a-zA-Z0-9_]{0,31}$`) before using them in `Path.Combine()`, rejecting path traversal sequences like `../../../test`
- Add `IsPathWithinDirectory` / `ThrowIfPathEscapesDirectory` defense-in-depth helpers that verify resolved paths stay within target directories after `Path.GetFullPath()`
- Apply both checks to all three affected methods (`UploadModule`, `UploadHelperModules`, `UploadSystemModule`) on both local and remote file paths
- Use the `return false` + status message pattern consistent with existing Controller.cs error handling

Closes #36

## Test plan
- [x] New `IsPathWithinDirectory` tests pass (safe path, traversal payload, absolute path outside base, null inputs)
- [x] New `ThrowIfPathEscapesDirectory` tests pass (safe path, traversal, outside base)
- [x] New `IsValidRapidIdentifier` path traversal tests pass (`../../../test`, `..\\..\\test`, `.`, `..`)
- [x] Existing tests remain green (no regressions)
- [x] CI passes on Windows (.NET Framework 4.8)