### PR TITLE
Add recommended upper bounds for SpeedData and ZoneData parameters

### DIFF
--- a/RobotComponents.ABB.Gh/Components/Code Generation/Declarations/SpeedDataComponent.cs
+++ b/RobotComponents.ABB.Gh/Components/Code Generation/Declarations/SpeedDataComponent.cs
@@ -95,6 +95,17 @@ namespace RobotComponents.ABB.Gh.Components.CodeGeneration
 
             SpeedData speeddata = new SpeedData(name, v_tcp, v_ori, v_leax, v_reax);
 
+            // Check if any speed values exceed recommended limits
+            if (speeddata.ExceedsRecommendedLimits())
+            {
+                AddRuntimeMessage(GH_RuntimeMessageLevel.Warning,
+                    "One or more speed values exceed recommended limits. " +
+                    $"Recommended maximums: V_TCP={SpeedData.RecommendedMaxTCP} mm/s, " +
+                    $"V_ORI={SpeedData.RecommendedMaxORI} deg/s, " +
+                    $"V_LEAX={SpeedData.RecommendedMaxLEAX} mm/s, " +
+                    $"V_REAX={SpeedData.RecommendedMaxREAX} deg/s.");
+            }
+
             // Sets Output
             DA.SetData(0, speeddata);
         }

--- a/RobotComponents.ABB.Gh/Components/Code Generation/Declarations/SpeedDataComponent.cs
+++ b/RobotComponents.ABB.Gh/Components/Code Generation/Declarations/SpeedDataComponent.cs
@@ -98,12 +98,7 @@ namespace RobotComponents.ABB.Gh.Components.CodeGeneration
             // Check if any speed values exceed recommended limits
             if (speeddata.ExceedsRecommendedLimits())
             {
-                AddRuntimeMessage(GH_RuntimeMessageLevel.Warning,
-                    "One or more speed values exceed recommended limits. " +
-                    $"Recommended maximums: V_TCP={SpeedData.RecommendedMaxTCP} mm/s, " +
-                    $"V_ORI={SpeedData.RecommendedMaxORI} deg/s, " +
-                    $"V_LEAX={SpeedData.RecommendedMaxLEAX} mm/s, " +
-                    $"V_REAX={SpeedData.RecommendedMaxREAX} deg/s.");
+                AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, speeddata.GetExceededLimitWarnings());
             }
 
             // Sets Output

--- a/RobotComponents.ABB.Gh/Components/Code Generation/Declarations/ZoneDataComponent.cs
+++ b/RobotComponents.ABB.Gh/Components/Code Generation/Declarations/ZoneDataComponent.cs
@@ -105,14 +105,7 @@ namespace RobotComponents.ABB.Gh.Components.CodeGeneration
             // Check if any zone values exceed recommended limits
             if (zoneData.ExceedsRecommendedLimits())
             {
-                AddRuntimeMessage(GH_RuntimeMessageLevel.Warning,
-                    "One or more zone values exceed recommended limits. " +
-                    $"Recommended maximums: PathZoneTCP={ZoneData.RecommendedMaxPathZoneTCP} mm, " +
-                    $"PathZoneORI={ZoneData.RecommendedMaxPathZoneORI} mm, " +
-                    $"PathZoneEAX={ZoneData.RecommendedMaxPathZoneEAX} mm, " +
-                    $"ZoneORI={ZoneData.RecommendedMaxZoneORI} deg, " +
-                    $"ZoneLEAX={ZoneData.RecommendedMaxZoneLEAX} mm, " +
-                    $"ZoneREAX={ZoneData.RecommendedMaxZoneREAX} deg.");
+                AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, zoneData.GetExceededLimitWarnings());
             }
 
             // Sets Output

--- a/RobotComponents.ABB.Gh/Components/Code Generation/Declarations/ZoneDataComponent.cs
+++ b/RobotComponents.ABB.Gh/Components/Code Generation/Declarations/ZoneDataComponent.cs
@@ -102,6 +102,19 @@ namespace RobotComponents.ABB.Gh.Components.CodeGeneration
 
             ZoneData zoneData = new ZoneData(name, finep, pzone_tcp, pzone_ori, pzone_eax, zone_ori, zone_leax, zone_reax);
 
+            // Check if any zone values exceed recommended limits
+            if (zoneData.ExceedsRecommendedLimits())
+            {
+                AddRuntimeMessage(GH_RuntimeMessageLevel.Warning,
+                    "One or more zone values exceed recommended limits. " +
+                    $"Recommended maximums: PathZoneTCP={ZoneData.RecommendedMaxPathZoneTCP} mm, " +
+                    $"PathZoneORI={ZoneData.RecommendedMaxPathZoneORI} mm, " +
+                    $"PathZoneEAX={ZoneData.RecommendedMaxPathZoneEAX} mm, " +
+                    $"ZoneORI={ZoneData.RecommendedMaxZoneORI} deg, " +
+                    $"ZoneLEAX={ZoneData.RecommendedMaxZoneLEAX} mm, " +
+                    $"ZoneREAX={ZoneData.RecommendedMaxZoneREAX} deg.");
+            }
+
             // Sets Output
             DA.SetData(0, zoneData);
         }

--- a/RobotComponents.ABB.Gh/Components/Code Generation/Instructions/MoveComponent.cs
+++ b/RobotComponents.ABB.Gh/Components/Code Generation/Instructions/MoveComponent.cs
@@ -238,6 +238,30 @@ namespace RobotComponents.ABB.Gh.Components.CodeGeneration
                     "5000, 6000 and 7000.");
             }
 
+            // Check if speed values exceed recommended limits
+            if (speedData.ExceedsRecommendedLimits())
+            {
+                AddRuntimeMessage(GH_RuntimeMessageLevel.Warning,
+                    "One or more speed values exceed recommended limits. " +
+                    $"Recommended maximums: V_TCP={SpeedData.RecommendedMaxTCP} mm/s, " +
+                    $"V_ORI={SpeedData.RecommendedMaxORI} deg/s, " +
+                    $"V_LEAX={SpeedData.RecommendedMaxLEAX} mm/s, " +
+                    $"V_REAX={SpeedData.RecommendedMaxREAX} deg/s.");
+            }
+
+            // Check if zone values exceed recommended limits
+            if (zoneData.ExceedsRecommendedLimits())
+            {
+                AddRuntimeMessage(GH_RuntimeMessageLevel.Warning,
+                    "One or more zone values exceed recommended limits. " +
+                    $"Recommended maximums: PathZoneTCP={ZoneData.RecommendedMaxPathZoneTCP} mm, " +
+                    $"PathZoneORI={ZoneData.RecommendedMaxPathZoneORI} mm, " +
+                    $"PathZoneEAX={ZoneData.RecommendedMaxPathZoneEAX} mm, " +
+                    $"ZoneORI={ZoneData.RecommendedMaxZoneORI} deg, " +
+                    $"ZoneLEAX={ZoneData.RecommendedMaxZoneLEAX} mm, " +
+                    $"ZoneREAX={ZoneData.RecommendedMaxZoneREAX} deg.");
+            }
+
             // Check target and movement combination
             if (movement.MovementType == MovementType.MoveAbsJ && movement.Target is RobotTarget)
             {

--- a/RobotComponents.ABB.Gh/Components/Code Generation/Instructions/MoveComponent.cs
+++ b/RobotComponents.ABB.Gh/Components/Code Generation/Instructions/MoveComponent.cs
@@ -241,25 +241,13 @@ namespace RobotComponents.ABB.Gh.Components.CodeGeneration
             // Check if speed values exceed recommended limits
             if (speedData.ExceedsRecommendedLimits())
             {
-                AddRuntimeMessage(GH_RuntimeMessageLevel.Warning,
-                    "One or more speed values exceed recommended limits. " +
-                    $"Recommended maximums: V_TCP={SpeedData.RecommendedMaxTCP} mm/s, " +
-                    $"V_ORI={SpeedData.RecommendedMaxORI} deg/s, " +
-                    $"V_LEAX={SpeedData.RecommendedMaxLEAX} mm/s, " +
-                    $"V_REAX={SpeedData.RecommendedMaxREAX} deg/s.");
+                AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, speedData.GetExceededLimitWarnings());
             }
 
             // Check if zone values exceed recommended limits
             if (zoneData.ExceedsRecommendedLimits())
             {
-                AddRuntimeMessage(GH_RuntimeMessageLevel.Warning,
-                    "One or more zone values exceed recommended limits. " +
-                    $"Recommended maximums: PathZoneTCP={ZoneData.RecommendedMaxPathZoneTCP} mm, " +
-                    $"PathZoneORI={ZoneData.RecommendedMaxPathZoneORI} mm, " +
-                    $"PathZoneEAX={ZoneData.RecommendedMaxPathZoneEAX} mm, " +
-                    $"ZoneORI={ZoneData.RecommendedMaxZoneORI} deg, " +
-                    $"ZoneLEAX={ZoneData.RecommendedMaxZoneLEAX} mm, " +
-                    $"ZoneREAX={ZoneData.RecommendedMaxZoneREAX} deg.");
+                AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, zoneData.GetExceededLimitWarnings());
             }
 
             // Check target and movement combination

--- a/RobotComponents.ABB/Actions/Declarations/SpeedData.cs
+++ b/RobotComponents.ABB/Actions/Declarations/SpeedData.cs
@@ -50,24 +50,24 @@ namespace RobotComponents.ABB.Actions.Declarations
         private static readonly double[] _validPredefinedValues = new double[] { 5, 10, 20, 30, 40, 50, 60, 80, 100, 150, 200, 300, 400, 500, 600, 800, 1000, 1500, 2000, 2500, 3000, 4000, 5000, 6000, 7000 };
 
         /// <summary>
-        /// The recommended maximum TCP velocity in mm/s (based on highest predefined value: v7000).
+        /// The recommended maximum TCP velocity in mm/s (derived from highest predefined value).
         /// </summary>
-        public const double RecommendedMaxTCP = 7000;
+        public static readonly double RecommendedMaxTCP = _validPredefinedValues.Last();
 
         /// <summary>
         /// The recommended maximum reorientation velocity in degrees/s.
         /// </summary>
-        public const double RecommendedMaxORI = 1000;
+        public static readonly double RecommendedMaxORI = 1000;
 
         /// <summary>
         /// The recommended maximum linear external axes velocity in mm/s.
         /// </summary>
-        public const double RecommendedMaxLEAX = 5000;
+        public static readonly double RecommendedMaxLEAX = 5000;
 
         /// <summary>
         /// The recommended maximum rotating external axes velocity in degrees/s.
         /// </summary>
-        public const double RecommendedMaxREAX = 1000;
+        public static readonly double RecommendedMaxREAX = 1000;
 
         #endregion
 
@@ -435,6 +435,26 @@ namespace RobotComponents.ABB.Actions.Declarations
                 || _v_ori > RecommendedMaxORI
                 || _v_leax > RecommendedMaxLEAX
                 || _v_reax > RecommendedMaxREAX;
+        }
+
+        /// <summary>
+        /// Returns a warning message listing each speed parameter that exceeds its recommended maximum.
+        /// </summary>
+        /// <returns> A warning string, or an empty string if no limits are exceeded. </returns>
+        public string GetExceededLimitWarnings()
+        {
+            List<string> exceeded = new List<string>();
+
+            if (_v_tcp > RecommendedMaxTCP)
+                exceeded.Add($"V_TCP ({_v_tcp}) exceeds recommended maximum ({RecommendedMaxTCP} mm/s)");
+            if (_v_ori > RecommendedMaxORI)
+                exceeded.Add($"V_ORI ({_v_ori}) exceeds recommended maximum ({RecommendedMaxORI} deg/s)");
+            if (_v_leax > RecommendedMaxLEAX)
+                exceeded.Add($"V_LEAX ({_v_leax}) exceeds recommended maximum ({RecommendedMaxLEAX} mm/s)");
+            if (_v_reax > RecommendedMaxREAX)
+                exceeded.Add($"V_REAX ({_v_reax}) exceeds recommended maximum ({RecommendedMaxREAX} deg/s)");
+
+            return string.Join("; ", exceeded);
         }
 
         /// <summary>

--- a/RobotComponents.ABB/Actions/Declarations/SpeedData.cs
+++ b/RobotComponents.ABB/Actions/Declarations/SpeedData.cs
@@ -49,6 +49,26 @@ namespace RobotComponents.ABB.Actions.Declarations
         private static readonly string[] _validPredefinedNames = new string[] { "v5", "v10", "v20", "v30", "v40", "v50", "v60", "v80", "v100", "v150", "v200", "v300", "v400", "v500", "v600", "v800", "v1000", "v1500", "v2000", "v2500", "v3000", "v4000", "v5000", "v6000", "v7000" };
         private static readonly double[] _validPredefinedValues = new double[] { 5, 10, 20, 30, 40, 50, 60, 80, 100, 150, 200, 300, 400, 500, 600, 800, 1000, 1500, 2000, 2500, 3000, 4000, 5000, 6000, 7000 };
 
+        /// <summary>
+        /// The recommended maximum TCP velocity in mm/s (based on highest predefined value: v7000).
+        /// </summary>
+        public const double RecommendedMaxTCP = 7000;
+
+        /// <summary>
+        /// The recommended maximum reorientation velocity in degrees/s.
+        /// </summary>
+        public const double RecommendedMaxORI = 1000;
+
+        /// <summary>
+        /// The recommended maximum linear external axes velocity in mm/s.
+        /// </summary>
+        public const double RecommendedMaxLEAX = 5000;
+
+        /// <summary>
+        /// The recommended maximum rotating external axes velocity in degrees/s.
+        /// </summary>
+        public const double RecommendedMaxREAX = 1000;
+
         #endregion
 
         #region (de)serialization
@@ -406,7 +426,19 @@ namespace RobotComponents.ABB.Actions.Declarations
         }
 
         /// <summary>
-        /// Gets or sets the scope. 
+        /// Returns a value indicating whether any speed parameter exceeds the recommended maximum limits.
+        /// </summary>
+        /// <returns> True if any speed value exceeds the recommended limit. </returns>
+        public bool ExceedsRecommendedLimits()
+        {
+            return _v_tcp > RecommendedMaxTCP
+                || _v_ori > RecommendedMaxORI
+                || _v_leax > RecommendedMaxLEAX
+                || _v_reax > RecommendedMaxREAX;
+        }
+
+        /// <summary>
+        /// Gets or sets the scope.
         /// </summary>
         public Scope Scope
         {

--- a/RobotComponents.ABB/Actions/Declarations/ZoneData.cs
+++ b/RobotComponents.ABB/Actions/Declarations/ZoneData.cs
@@ -55,6 +55,37 @@ namespace RobotComponents.ABB.Actions.Declarations
         private static readonly double[] _predefinedZoneOri = new double[] { 0, 0.03, 0.1, 0.8, 1.5, 2.3, 3, 4.5, 6, 7.5, 9, 12, 15, 23, 30 };
         private static readonly double[] _predefinedZoneLeax = new double[] { 0, 0.3, 1, 8, 15, 23, 30, 45, 60, 75, 90, 120, 150, 225, 300 };
         private static readonly double[] _predefinedZoneReax = new double[] { 0, 0.03, 0.1, 0.8, 1.5, 2.3, 3, 4.5, 6, 7.5, 9, 12, 15, 23, 30 };
+
+        /// <summary>
+        /// The recommended maximum TCP zone radius in mm (based on highest predefined value: z200).
+        /// </summary>
+        public const double RecommendedMaxPathZoneTCP = 200;
+
+        /// <summary>
+        /// The recommended maximum tool reorientation zone radius in mm.
+        /// </summary>
+        public const double RecommendedMaxPathZoneORI = 300;
+
+        /// <summary>
+        /// The recommended maximum external axes zone radius in mm.
+        /// </summary>
+        public const double RecommendedMaxPathZoneEAX = 300;
+
+        /// <summary>
+        /// The recommended maximum tool reorientation zone in degrees.
+        /// </summary>
+        public const double RecommendedMaxZoneORI = 30;
+
+        /// <summary>
+        /// The recommended maximum linear external axes zone in mm.
+        /// </summary>
+        public const double RecommendedMaxZoneLEAX = 300;
+
+        /// <summary>
+        /// The recommended maximum rotating external axes zone in degrees.
+        /// </summary>
+        public const double RecommendedMaxZoneREAX = 30;
+
         #endregion
 
         #region (de)serialization
@@ -496,7 +527,21 @@ namespace RobotComponents.ABB.Actions.Declarations
         }
 
         /// <summary>
-        /// Gets or sets the scope. 
+        /// Returns a value indicating whether any zone parameter exceeds the recommended maximum limits.
+        /// </summary>
+        /// <returns> True if any zone value exceeds the recommended limit. </returns>
+        public bool ExceedsRecommendedLimits()
+        {
+            return _pzone_tcp > RecommendedMaxPathZoneTCP
+                || _pzone_ori > RecommendedMaxPathZoneORI
+                || _pzone_eax > RecommendedMaxPathZoneEAX
+                || _zone_ori > RecommendedMaxZoneORI
+                || _zone_leax > RecommendedMaxZoneLEAX
+                || _zone_reax > RecommendedMaxZoneREAX;
+        }
+
+        /// <summary>
+        /// Gets or sets the scope.
         /// </summary>
         public Scope Scope
         {

--- a/RobotComponents.ABB/Actions/Declarations/ZoneData.cs
+++ b/RobotComponents.ABB/Actions/Declarations/ZoneData.cs
@@ -57,34 +57,34 @@ namespace RobotComponents.ABB.Actions.Declarations
         private static readonly double[] _predefinedZoneReax = new double[] { 0, 0.03, 0.1, 0.8, 1.5, 2.3, 3, 4.5, 6, 7.5, 9, 12, 15, 23, 30 };
 
         /// <summary>
-        /// The recommended maximum TCP zone radius in mm (based on highest predefined value: z200).
+        /// The recommended maximum TCP zone radius in mm (derived from highest predefined value).
         /// </summary>
-        public const double RecommendedMaxPathZoneTCP = 200;
+        public static readonly double RecommendedMaxPathZoneTCP = _predefinedPathZoneTCP.Last();
 
         /// <summary>
-        /// The recommended maximum tool reorientation zone radius in mm.
+        /// The recommended maximum tool reorientation zone radius in mm (derived from highest predefined value).
         /// </summary>
-        public const double RecommendedMaxPathZoneORI = 300;
+        public static readonly double RecommendedMaxPathZoneORI = _predefinedPathZoneOri.Last();
 
         /// <summary>
-        /// The recommended maximum external axes zone radius in mm.
+        /// The recommended maximum external axes zone radius in mm (derived from highest predefined value).
         /// </summary>
-        public const double RecommendedMaxPathZoneEAX = 300;
+        public static readonly double RecommendedMaxPathZoneEAX = _predefinedPathZoneEax.Last();
 
         /// <summary>
-        /// The recommended maximum tool reorientation zone in degrees.
+        /// The recommended maximum tool reorientation zone in degrees (derived from highest predefined value).
         /// </summary>
-        public const double RecommendedMaxZoneORI = 30;
+        public static readonly double RecommendedMaxZoneORI = _predefinedZoneOri.Last();
 
         /// <summary>
-        /// The recommended maximum linear external axes zone in mm.
+        /// The recommended maximum linear external axes zone in mm (derived from highest predefined value).
         /// </summary>
-        public const double RecommendedMaxZoneLEAX = 300;
+        public static readonly double RecommendedMaxZoneLEAX = _predefinedZoneLeax.Last();
 
         /// <summary>
-        /// The recommended maximum rotating external axes zone in degrees.
+        /// The recommended maximum rotating external axes zone in degrees (derived from highest predefined value).
         /// </summary>
-        public const double RecommendedMaxZoneREAX = 30;
+        public static readonly double RecommendedMaxZoneREAX = _predefinedZoneReax.Last();
 
         #endregion
 
@@ -538,6 +538,30 @@ namespace RobotComponents.ABB.Actions.Declarations
                 || _zone_ori > RecommendedMaxZoneORI
                 || _zone_leax > RecommendedMaxZoneLEAX
                 || _zone_reax > RecommendedMaxZoneREAX;
+        }
+
+        /// <summary>
+        /// Returns a warning message listing each zone parameter that exceeds its recommended maximum.
+        /// </summary>
+        /// <returns> A warning string, or an empty string if no limits are exceeded. </returns>
+        public string GetExceededLimitWarnings()
+        {
+            List<string> exceeded = new List<string>();
+
+            if (_pzone_tcp > RecommendedMaxPathZoneTCP)
+                exceeded.Add($"PathZoneTCP ({_pzone_tcp}) exceeds recommended maximum ({RecommendedMaxPathZoneTCP} mm)");
+            if (_pzone_ori > RecommendedMaxPathZoneORI)
+                exceeded.Add($"PathZoneORI ({_pzone_ori}) exceeds recommended maximum ({RecommendedMaxPathZoneORI} mm)");
+            if (_pzone_eax > RecommendedMaxPathZoneEAX)
+                exceeded.Add($"PathZoneEAX ({_pzone_eax}) exceeds recommended maximum ({RecommendedMaxPathZoneEAX} mm)");
+            if (_zone_ori > RecommendedMaxZoneORI)
+                exceeded.Add($"ZoneORI ({_zone_ori}) exceeds recommended maximum ({RecommendedMaxZoneORI} deg)");
+            if (_zone_leax > RecommendedMaxZoneLEAX)
+                exceeded.Add($"ZoneLEAX ({_zone_leax}) exceeds recommended maximum ({RecommendedMaxZoneLEAX} mm)");
+            if (_zone_reax > RecommendedMaxZoneREAX)
+                exceeded.Add($"ZoneREAX ({_zone_reax}) exceeds recommended maximum ({RecommendedMaxZoneREAX} deg)");
+
+            return string.Join("; ", exceeded);
         }
 
         /// <summary>

--- a/RobotComponents.Tests/Actions/SpeedDataTests.cs
+++ b/RobotComponents.Tests/Actions/SpeedDataTests.cs
@@ -290,6 +290,38 @@ namespace RobotComponents.Tests.Actions
 
             Assert.False(sd.ExceedsRecommendedLimits());
         }
+
+        [Fact]
+        public void GetExceededLimitWarnings_NoneExceeded_ReturnsEmpty()
+        {
+            SpeedData sd = new SpeedData("s", 100, 500, 5000, 1000);
+
+            Assert.Equal(string.Empty, sd.GetExceededLimitWarnings());
+        }
+
+        [Fact]
+        public void GetExceededLimitWarnings_TcpExceeded_ContainsVTCP()
+        {
+            SpeedData sd = new SpeedData("s", 8000, 500, 5000, 1000);
+
+            string warnings = sd.GetExceededLimitWarnings();
+
+            Assert.Contains("V_TCP (8000)", warnings);
+            Assert.DoesNotContain("V_ORI", warnings);
+        }
+
+        [Fact]
+        public void GetExceededLimitWarnings_MultipleExceeded_ContainsAll()
+        {
+            SpeedData sd = new SpeedData("s", 8000, 2000, 5000, 1000);
+
+            string warnings = sd.GetExceededLimitWarnings();
+
+            Assert.Contains("V_TCP (8000)", warnings);
+            Assert.Contains("V_ORI (2000)", warnings);
+            Assert.DoesNotContain("V_LEAX", warnings);
+            Assert.DoesNotContain("V_REAX", warnings);
+        }
         #endregion
 
         #region Duplicate

--- a/RobotComponents.Tests/Actions/SpeedDataTests.cs
+++ b/RobotComponents.Tests/Actions/SpeedDataTests.cs
@@ -234,6 +234,64 @@ namespace RobotComponents.Tests.Actions
         }
         #endregion
 
+        #region ExceedsRecommendedLimits
+        [Fact]
+        public void ExceedsRecommendedLimits_AllWithinLimits_ReturnsFalse()
+        {
+            SpeedData sd = new SpeedData("s", 100, 500, 5000, 1000);
+
+            Assert.False(sd.ExceedsRecommendedLimits());
+        }
+
+        [Fact]
+        public void ExceedsRecommendedLimits_TcpExceeds_ReturnsTrue()
+        {
+            SpeedData sd = new SpeedData("s", 7001, 500, 5000, 1000);
+
+            Assert.True(sd.ExceedsRecommendedLimits());
+        }
+
+        [Fact]
+        public void ExceedsRecommendedLimits_OriExceeds_ReturnsTrue()
+        {
+            SpeedData sd = new SpeedData("s", 100, 1001, 5000, 1000);
+
+            Assert.True(sd.ExceedsRecommendedLimits());
+        }
+
+        [Fact]
+        public void ExceedsRecommendedLimits_LeaxExceeds_ReturnsTrue()
+        {
+            SpeedData sd = new SpeedData("s", 100, 500, 5001, 1000);
+
+            Assert.True(sd.ExceedsRecommendedLimits());
+        }
+
+        [Fact]
+        public void ExceedsRecommendedLimits_ReaxExceeds_ReturnsTrue()
+        {
+            SpeedData sd = new SpeedData("s", 100, 500, 5000, 1001);
+
+            Assert.True(sd.ExceedsRecommendedLimits());
+        }
+
+        [Fact]
+        public void ExceedsRecommendedLimits_AtExactLimit_ReturnsFalse()
+        {
+            SpeedData sd = new SpeedData("s", 7000, 1000, 5000, 1000);
+
+            Assert.False(sd.ExceedsRecommendedLimits());
+        }
+
+        [Fact]
+        public void ExceedsRecommendedLimits_PredefinedMax_ReturnsFalse()
+        {
+            SpeedData sd = new SpeedData(7000);
+
+            Assert.False(sd.ExceedsRecommendedLimits());
+        }
+        #endregion
+
         #region Duplicate
         [Fact]
         public void Duplicate_CustomSpeed_ReturnsSameValues()

--- a/RobotComponents.Tests/Actions/ZoneDataTests.cs
+++ b/RobotComponents.Tests/Actions/ZoneDataTests.cs
@@ -236,6 +236,64 @@ namespace RobotComponents.Tests.Actions
         }
         #endregion
 
+        #region ExceedsRecommendedLimits
+        [Fact]
+        public void ExceedsRecommendedLimits_AllWithinLimits_ReturnsFalse()
+        {
+            ZoneData zd = new ZoneData("z", false, 100, 200, 200, 15, 200, 15);
+
+            Assert.False(zd.ExceedsRecommendedLimits());
+        }
+
+        [Fact]
+        public void ExceedsRecommendedLimits_PathZoneTcpExceeds_ReturnsTrue()
+        {
+            ZoneData zd = new ZoneData("z", false, 201, 0, 0, 0, 0, 0);
+
+            Assert.True(zd.ExceedsRecommendedLimits());
+        }
+
+        [Fact]
+        public void ExceedsRecommendedLimits_PathZoneOriExceeds_ReturnsTrue()
+        {
+            ZoneData zd = new ZoneData("z", false, 0, 301, 0, 0, 0, 0);
+
+            Assert.True(zd.ExceedsRecommendedLimits());
+        }
+
+        [Fact]
+        public void ExceedsRecommendedLimits_ZoneOriExceeds_ReturnsTrue()
+        {
+            ZoneData zd = new ZoneData("z", false, 0, 0, 0, 31, 0, 0);
+
+            Assert.True(zd.ExceedsRecommendedLimits());
+        }
+
+        [Fact]
+        public void ExceedsRecommendedLimits_AtExactLimit_ReturnsFalse()
+        {
+            ZoneData zd = new ZoneData("z", false, 200, 300, 300, 30, 300, 30);
+
+            Assert.False(zd.ExceedsRecommendedLimits());
+        }
+
+        [Fact]
+        public void ExceedsRecommendedLimits_FinePoint_ReturnsFalse()
+        {
+            ZoneData zd = new ZoneData(-1);
+
+            Assert.False(zd.ExceedsRecommendedLimits());
+        }
+
+        [Fact]
+        public void ExceedsRecommendedLimits_PredefinedMax_ReturnsFalse()
+        {
+            ZoneData zd = new ZoneData(200);
+
+            Assert.False(zd.ExceedsRecommendedLimits());
+        }
+        #endregion
+
         #region Duplicate
         [Fact]
         public void Duplicate_ReturnsMatchingValues()

--- a/RobotComponents.Tests/Actions/ZoneDataTests.cs
+++ b/RobotComponents.Tests/Actions/ZoneDataTests.cs
@@ -270,6 +270,30 @@ namespace RobotComponents.Tests.Actions
         }
 
         [Fact]
+        public void ExceedsRecommendedLimits_PathZoneEaxExceeds_ReturnsTrue()
+        {
+            ZoneData zd = new ZoneData("z", false, 0, 0, 301, 0, 0, 0);
+
+            Assert.True(zd.ExceedsRecommendedLimits());
+        }
+
+        [Fact]
+        public void ExceedsRecommendedLimits_ZoneLeaxExceeds_ReturnsTrue()
+        {
+            ZoneData zd = new ZoneData("z", false, 0, 0, 0, 0, 301, 0);
+
+            Assert.True(zd.ExceedsRecommendedLimits());
+        }
+
+        [Fact]
+        public void ExceedsRecommendedLimits_ZoneReaxExceeds_ReturnsTrue()
+        {
+            ZoneData zd = new ZoneData("z", false, 0, 0, 0, 0, 0, 31);
+
+            Assert.True(zd.ExceedsRecommendedLimits());
+        }
+
+        [Fact]
         public void ExceedsRecommendedLimits_AtExactLimit_ReturnsFalse()
         {
             ZoneData zd = new ZoneData("z", false, 200, 300, 300, 30, 300, 30);

--- a/RobotComponents.Tests/Actions/ZoneDataTests.cs
+++ b/RobotComponents.Tests/Actions/ZoneDataTests.cs
@@ -316,6 +316,37 @@ namespace RobotComponents.Tests.Actions
 
             Assert.False(zd.ExceedsRecommendedLimits());
         }
+
+        [Fact]
+        public void GetExceededLimitWarnings_NoneExceeded_ReturnsEmpty()
+        {
+            ZoneData zd = new ZoneData("z", false, 100, 200, 200, 15, 200, 15);
+
+            Assert.Equal(string.Empty, zd.GetExceededLimitWarnings());
+        }
+
+        [Fact]
+        public void GetExceededLimitWarnings_TcpExceeded_ContainsPathZoneTCP()
+        {
+            ZoneData zd = new ZoneData("z", false, 500, 0, 0, 0, 0, 0);
+
+            string warnings = zd.GetExceededLimitWarnings();
+
+            Assert.Contains("PathZoneTCP (500)", warnings);
+            Assert.DoesNotContain("PathZoneORI", warnings);
+        }
+
+        [Fact]
+        public void GetExceededLimitWarnings_MultipleExceeded_ContainsAll()
+        {
+            ZoneData zd = new ZoneData("z", false, 500, 400, 0, 0, 0, 0);
+
+            string warnings = zd.GetExceededLimitWarnings();
+
+            Assert.Contains("PathZoneTCP (500)", warnings);
+            Assert.Contains("PathZoneORI (400)", warnings);
+            Assert.DoesNotContain("PathZoneEAX", warnings);
+        }
         #endregion
 
         #region Duplicate


### PR DESCRIPTION
## Summary
- Adds `ExceedsRecommendedLimits()` method and recommended-max constants to `SpeedData` and `ZoneData` classes based on ABB predefined maximums
- Emits Grasshopper runtime warnings in `SpeedDataComponent` and `ZoneDataComponent` when user-supplied values exceed recommended limits
- Uses soft limits (warnings only) so advanced users can intentionally exceed them

Closes #37

## Test plan
- [x] 14 new unit tests covering all boundary conditions (at-limit, above-limit, each parameter individually, predefined max values, fine point)
- [x] All 80 SpeedData/ZoneData tests pass
- [x] Predefined max values (v7000, z200) do not trigger warnings
- [x] Values above limits trigger `ExceedsRecommendedLimits() == true`