### PR TITLE
Enforce axis limit violations in RAPID generation

### DIFF
--- a/RobotComponents.ABB.Gh/Components/Code Generation/Generators/RAPIDGeneratorComponent.cs
+++ b/RobotComponents.ABB.Gh/Components/Code Generation/Generators/RAPIDGeneratorComponent.cs
@@ -399,6 +399,7 @@ namespace RobotComponents.ABB.Gh.Components.CodeGeneration
             Menu_AppendItem(menu, "Add Load Data", MenuItemClickLoaddata, true, _addLoaddataInputParam);
             Menu_AppendItem(menu, "Add Tool Data", MenuItemClickTooldata, true, _addTooldataInputParam);
             Menu_AppendItem(menu, "Add Work Object Data", MenuItemClickWobjdata, true, _addWobjdataInputParam);
+            Menu_AppendSeparator(menu);
             Menu_AppendItem(menu, "Enforce Axis Limits", MenuItemClickEnforceAxisLimits, true, _enforceAxisLimitsInputParam);
             Menu_AppendSeparator(menu);
             Menu_AppendItem(menu, "Output Load Data", MenuItemClickOutputLoaddata, true, _loaddataOutputParam);

--- a/RobotComponents.ABB.Gh/Components/Code Generation/Generators/RAPIDGeneratorComponent.cs
+++ b/RobotComponents.ABB.Gh/Components/Code Generation/Generators/RAPIDGeneratorComponent.cs
@@ -318,7 +318,7 @@ namespace RobotComponents.ABB.Gh.Components.CodeGeneration
                 for (int i = 0; i < _rapidGenerator.ErrorText.Count; i++)
                 {
                     AddRuntimeMessage(level, _rapidGenerator.ErrorText[i]);
-                    if (i == 30) { break; }
+                    if (i == 29) { break; }
                 }
             }
 

--- a/RobotComponents.ABB.Gh/Components/Code Generation/Generators/RAPIDGeneratorComponent.cs
+++ b/RobotComponents.ABB.Gh/Components/Code Generation/Generators/RAPIDGeneratorComponent.cs
@@ -57,6 +57,7 @@ namespace RobotComponents.ABB.Gh.Components.CodeGeneration
         private bool _addLoaddataInputParam = false;
         private bool _addTooldataInputParam = false;
         private bool _addWobjdataInputParam = false;
+        private bool _enforceAxisLimitsInputParam = false;
         private readonly int _fixedParamNumInput = 2;
         private bool _loaddataOutputParam = false;
         private bool _tooldataOutputParam = false;
@@ -81,7 +82,7 @@ namespace RobotComponents.ABB.Gh.Components.CodeGeneration
         /// <summary>
         /// Stores the variable input parameters in an array.
         /// </summary>
-        private readonly IGH_Param[] _variableInputParameters = new IGH_Param[10]
+        private readonly IGH_Param[] _variableInputParameters = new IGH_Param[11]
         {
             new Param_Boolean() { Name = "Is System Moudle", NickName = "SM", Description = "Indicates whether this module should be uploaded as a System Module.", Access = GH_ParamAccess.item, Optional = true},
             new Param_String() { Name = "Module Name", NickName = "MN", Description = "The name of the module as a text. The default name is MainModule.", Access = GH_ParamAccess.item, Optional = true},
@@ -92,7 +93,8 @@ namespace RobotComponents.ABB.Gh.Components.CodeGeneration
             new Param_Boolean() { Name = "Add loaddata", NickName = "AL", Description = "Indicates if the loaddata should be added to the RAPID module.", Access = GH_ParamAccess.item, Optional = true},
             new Param_Boolean() { Name = "Add tooldata", NickName = "AT", Description = "Indicates if the tooldata should be added to the RAPID module.", Access = GH_ParamAccess.item, Optional = true},
             new Param_Boolean() { Name = "Add wobjdata", NickName = "AW", Description = "Indicates if the wobjdata should be added the RAPID module.", Access = GH_ParamAccess.item, Optional = true},
-            new Param_Boolean() { Name = "Update", NickName = "U", Description = "Updates the RAPID module based on a boolean value. To increase performance, only update when changes were made.", Access = GH_ParamAccess.item, Optional = true }
+            new Param_Boolean() { Name = "Update", NickName = "U", Description = "Updates the RAPID module based on a boolean value. To increase performance, only update when changes were made.", Access = GH_ParamAccess.item, Optional = true },
+            new Param_Boolean() { Name = "Enforce Axis Limits", NickName = "EL", Description = "When true (default), axis limit violations prevent RAPID code generation. Set to false to allow generation with warnings only.", Access = GH_ParamAccess.item, Optional = true}
         };
 
         /// <summary>
@@ -144,6 +146,7 @@ namespace RobotComponents.ABB.Gh.Components.CodeGeneration
             bool addLoaddata = true;
             bool addWobjdata = true;
             bool update = true;
+            bool enforceAxisLimits = true;
 
             // Catch the input data
             if (!DA.GetData(0, ref robot)) { return; }
@@ -228,6 +231,13 @@ namespace RobotComponents.ABB.Gh.Components.CodeGeneration
                     update = true;
                 }
             }
+            if (Params.Input.Any(x => x.Name == _variableInputParameters[10].Name))
+            {
+                if (!DA.GetData(_variableInputParameters[10].Name, ref enforceAxisLimits))
+                {
+                    enforceAxisLimits = true;
+                }
+            }
 
             // Checks if module name exceeds max character limit for RAPID Code
             if (HelperMethods.StringExeedsCharacterLimit32(moduleName))
@@ -278,6 +288,7 @@ namespace RobotComponents.ABB.Gh.Components.CodeGeneration
 
                 // Initiaties the rapidGenerator
                 _rapidGenerator = new RAPIDGenerator(robot, moduleName, routineName, (Scope)scope, mainModule, additionalRoutines, isSystemModule);
+                _rapidGenerator.EnforceAxisLimits = enforceAxisLimits;
 
                 // Generator code
                 _rapidGenerator.CreateModule(actions, addTooldata, addWobjdata, addLoaddata);
@@ -295,14 +306,18 @@ namespace RobotComponents.ABB.Gh.Components.CodeGeneration
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "The first movement is not set as an absolute joint movement.");
             }
 
-            // Show warning messages
+            // Show error or warning messages for axis limit violations
             if (_rapidGenerator.ErrorText.Count != 0)
             {
-                AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "Only axis values of absolute joint movements are checked.");
+                GH_RuntimeMessageLevel level = _rapidGenerator.EnforceAxisLimits
+                    ? GH_RuntimeMessageLevel.Error
+                    : GH_RuntimeMessageLevel.Warning;
+
+                AddRuntimeMessage(level, "Only axis values of absolute joint movements are checked.");
 
                 for (int i = 0; i < _rapidGenerator.ErrorText.Count; i++)
                 {
-                    AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, _rapidGenerator.ErrorText[i]);
+                    AddRuntimeMessage(level, _rapidGenerator.ErrorText[i]);
                     if (i == 30) { break; }
                 }
             }
@@ -384,6 +399,7 @@ namespace RobotComponents.ABB.Gh.Components.CodeGeneration
             Menu_AppendItem(menu, "Add Load Data", MenuItemClickLoaddata, true, _addLoaddataInputParam);
             Menu_AppendItem(menu, "Add Tool Data", MenuItemClickTooldata, true, _addTooldataInputParam);
             Menu_AppendItem(menu, "Add Work Object Data", MenuItemClickWobjdata, true, _addWobjdataInputParam);
+            Menu_AppendItem(menu, "Enforce Axis Limits", MenuItemClickEnforceAxisLimits, true, _enforceAxisLimitsInputParam);
             Menu_AppendSeparator(menu);
             Menu_AppendItem(menu, "Output Load Data", MenuItemClickOutputLoaddata, true, _loaddataOutputParam);
             Menu_AppendItem(menu, "Output Tool Data", MenuItemClickOutputTooldata, true, _tooldataOutputParam);
@@ -498,6 +514,18 @@ namespace RobotComponents.ABB.Gh.Components.CodeGeneration
         }
 
         /// <summary>
+        /// Handles the event when the custom menu item "Enforce Axis Limits" is clicked.
+        /// </summary>
+        /// <param name="sender"> The object that raises the event. </param>
+        /// <param name="e"> The event data. </param>
+        private void MenuItemClickEnforceAxisLimits(object sender, EventArgs e)
+        {
+            RecordUndoEvent("Enforce Axis Limits");
+            _enforceAxisLimitsInputParam = !_enforceAxisLimitsInputParam;
+            AddInputParameter(10);
+        }
+
+        /// <summary>
         /// Handles the event when the custom menu item "Output Load Data" is clicked. 
         /// </summary>
         /// <param name="sender"> The object that raises the event. </param>
@@ -595,6 +623,7 @@ namespace RobotComponents.ABB.Gh.Components.CodeGeneration
             writer.SetBoolean("Output loaddata", _loaddataOutputParam);
             writer.SetBoolean("Output tooldata", _tooldataOutputParam);
             writer.SetBoolean("Output wobjdata", _wobjdataOutputParam);
+            writer.SetBoolean("Enforce Axis Limits", _enforceAxisLimitsInputParam);
             return base.Write(writer);
         }
 
@@ -617,6 +646,10 @@ namespace RobotComponents.ABB.Gh.Components.CodeGeneration
             _loaddataOutputParam = reader.GetBoolean("Output loaddata");
             _tooldataOutputParam = reader.GetBoolean("Output tooldata");
             _wobjdataOutputParam = reader.GetBoolean("Output wobjdata");
+            if (reader.ItemExists("Enforce Axis Limits"))
+            {
+                _enforceAxisLimitsInputParam = reader.GetBoolean("Enforce Axis Limits");
+            }
             return base.Read(reader);
         }
 

--- a/RobotComponents.ABB/Actions/Instructions/Movement.cs
+++ b/RobotComponents.ABB/Actions/Instructions/Movement.cs
@@ -560,12 +560,13 @@ namespace RobotComponents.ABB.Actions.Instructions
                     RAPIDGenerator.ErrorText.AddRange(new List<string>(RAPIDGenerator.Robot.InverseKinematics.ErrorText));
 
                     // Create a joint target from the axis values
-                    _convertedTarget = new JointTarget(robotTarget.Name, RAPIDGenerator.Robot.InverseKinematics.RobotJointPosition.Duplicate(), RAPIDGenerator.Robot.InverseKinematics.ExternalJointPosition.Duplicate());
+                    JointTarget convertedJointTarget = new JointTarget(robotTarget.Name, RAPIDGenerator.Robot.InverseKinematics.RobotJointPosition.Duplicate(), RAPIDGenerator.Robot.InverseKinematics.ExternalJointPosition.Duplicate());
+                    _convertedTarget = convertedJointTarget;
                     _convertedTarget.ExternalJointPosition.Name = _target.ExternalJointPosition.Name;
                     _convertedTarget.VariableType = _target.VariableType;
 
                     // Check axis limits on the converted joint target
-                    RAPIDGenerator.ErrorText.AddRange(((JointTarget)_convertedTarget).CheckAxisLimits(RAPIDGenerator.Robot));
+                    RAPIDGenerator.ErrorText.AddRange(convertedJointTarget.CheckAxisLimits(RAPIDGenerator.Robot));
 
                     if (_convertedTarget.Name != "")
                     {

--- a/RobotComponents.ABB/Actions/Instructions/Movement.cs
+++ b/RobotComponents.ABB/Actions/Instructions/Movement.cs
@@ -564,6 +564,9 @@ namespace RobotComponents.ABB.Actions.Instructions
                     _convertedTarget.ExternalJointPosition.Name = _target.ExternalJointPosition.Name;
                     _convertedTarget.VariableType = _target.VariableType;
 
+                    // Check axis limits on the converted joint target
+                    RAPIDGenerator.ErrorText.AddRange(((JointTarget)_convertedTarget).CheckAxisLimits(RAPIDGenerator.Robot));
+
                     if (_convertedTarget.Name != "")
                     {
                         _convertedTarget.Name += "_jt";

--- a/RobotComponents.ABB/Actions/RAPIDGenerator.cs
+++ b/RobotComponents.ABB/Actions/RAPIDGenerator.cs
@@ -81,6 +81,7 @@ namespace RobotComponents.ABB.Actions
 
         // Checks
         private readonly List<string> _errorText = new List<string>();
+        private bool _enforceAxisLimits = true;
         private bool _isFirstMovementMoveAbsJ;
         private bool _isSynchronized = false;
         #endregion
@@ -135,6 +136,7 @@ namespace RobotComponents.ABB.Actions
             _procedureName = generator.ProcedureName;
             _robot = generator.Robot.Duplicate();
             _isFirstMovementMoveAbsJ = generator.IsFirstMovementMoveAbsJ;
+            _enforceAxisLimits = generator.EnforceAxisLimits;
             _scope = generator.RoutineScope;
             _mainModule = generator._mainModule;
             _additionalRoutines = generator._additionalRoutines;
@@ -785,11 +787,23 @@ namespace RobotComponents.ABB.Actions
         }
 
         /// <summary>
-        /// Gets the collected error messages. 
+        /// Gets the collected error messages.
         /// </summary>
         public List<string> ErrorText
         {
             get { return _errorText; }
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether axis limit violations should prevent
+        /// RAPID module generation. When true (default), CreateModule returns an empty
+        /// module and populates ErrorText if any violations are detected. When false,
+        /// violations are reported in ErrorText as warnings but code generation proceeds.
+        /// </summary>
+        public bool EnforceAxisLimits
+        {
+            get { return _enforceAxisLimits; }
+            set { _enforceAxisLimits = value; }
         }
 
         /// <summary>

--- a/RobotComponents.ABB/Actions/RAPIDGenerator.cs
+++ b/RobotComponents.ABB/Actions/RAPIDGenerator.cs
@@ -807,10 +807,11 @@ namespace RobotComponents.ABB.Actions
         }
 
         /// <summary>
-        /// Gets or sets a value indicating whether axis limit violations should prevent
-        /// RAPID module generation. When true (default), CreateModule returns an empty
-        /// module and populates ErrorText if any violations are detected. When false,
-        /// violations are reported in ErrorText as warnings but code generation proceeds.
+        /// Gets or sets a value indicating whether axis limit violations and other
+        /// errors detected during target conversion should prevent RAPID module generation.
+        /// When true (default), CreateModule returns an empty module and populates ErrorText
+        /// if any errors are detected. When false, errors are reported in ErrorText as
+        /// warnings but code generation proceeds.
         /// </summary>
         public bool EnforceAxisLimits
         {

--- a/RobotComponents.ABB/Actions/RAPIDGenerator.cs
+++ b/RobotComponents.ABB/Actions/RAPIDGenerator.cs
@@ -272,6 +272,18 @@ namespace RobotComponents.ABB.Actions
                     }
                 }
             }
+
+            // Collect errors from additional routine generators
+            foreach (RAPIDGenerator routineGenerator in _additionalRoutineGenerators)
+            {
+                _errorText.AddRange(routineGenerator.ErrorText);
+            }
+
+            // Abort module generation if violations are detected and enforcement is enabled
+            if (_enforceAxisLimits && _errorText.Count > 0)
+            {
+                return _module;
+            }
             #endregion
 
             #region write the module

--- a/RobotComponents.Tests/Actions/MovementTests.cs
+++ b/RobotComponents.Tests/Actions/MovementTests.cs
@@ -27,6 +27,8 @@ namespace RobotComponents.Tests.Actions
     {
         /// <summary>
         /// Creates a test robot and generates a RAPID module from the given actions.
+        /// EnforceAxisLimits defaults to true, so actions with out-of-range values will
+        /// produce an empty module.
         /// </summary>
         private List<string> GenerateModule(IList<IAction> actions)
         {

--- a/RobotComponents.Tests/Actions/MovementTests.cs
+++ b/RobotComponents.Tests/Actions/MovementTests.cs
@@ -35,6 +35,18 @@ namespace RobotComponents.Tests.Actions
             return generator.CreateModule(actions);
         }
 
+        /// <summary>
+        /// Creates a test robot and generates a RAPID module, returning the generator for error inspection.
+        /// </summary>
+        private RAPIDGenerator GenerateModuleWithGenerator(IList<IAction> actions, bool enforceAxisLimits = true)
+        {
+            Robot robot = Factory.GetRobotPreset(RobotPreset.IRB120_3_058, Plane.WorldXY);
+            RAPIDGenerator generator = new RAPIDGenerator(robot);
+            generator.EnforceAxisLimits = enforceAxisLimits;
+            generator.CreateModule(actions);
+            return generator;
+        }
+
         #region MoveAbsJ
         [Fact]
         [Trait("Category", "RequiresRhino")]
@@ -309,6 +321,25 @@ namespace RobotComponents.Tests.Actions
             string joined = string.Join(Environment.NewLine, module);
 
             Assert.DoesNotContain("\\T", joined);
+        }
+        #endregion
+
+        #region Axis Limit Check on IK-Converted Target
+        [Fact]
+        [Trait("Category", "RequiresRhino")]
+        public void MoveAbsJ_RobotTargetConvertedViaIK_ChecksAxisLimits()
+        {
+            // Place a target behind the robot so IK produces axis 1 near ±180°,
+            // exceeding the IRB120's [-165, 165] limit for axis 1.
+            Plane behindRobot = new Plane(new Point3d(-300, 0, 300), -Vector3d.XAxis, Vector3d.ZAxis);
+            RobotTarget target = new RobotTarget("rt_behind", behindRobot);
+            Movement move = new Movement(MovementType.MoveAbsJ, target, new SpeedData(100), new ZoneData(10));
+
+            RAPIDGenerator generator = GenerateModuleWithGenerator(new List<IAction> { move }, enforceAxisLimits: false);
+
+            // The IK-converted JointTarget should produce axis limit errors
+            Assert.NotEmpty(generator.ErrorText);
+            Assert.Contains(generator.ErrorText, e => e.Contains("not in range"));
         }
         #endregion
 

--- a/RobotComponents.Tests/Actions/RAPIDGeneratorTests.cs
+++ b/RobotComponents.Tests/Actions/RAPIDGeneratorTests.cs
@@ -338,6 +338,32 @@ namespace RobotComponents.Tests.Actions
             Assert.Contains("ENDMODULE", joined);
             Assert.Empty(generator.ErrorText);
         }
+
+        [Fact]
+        [Trait("Category", "RequiresRhino")]
+        public void Duplicate_PreservesEnforceAxisLimits_True()
+        {
+            Robot robot = CreateTestRobot();
+            RAPIDGenerator generator = new RAPIDGenerator(robot);
+            generator.EnforceAxisLimits = true;
+
+            RAPIDGenerator copy = generator.Duplicate();
+
+            Assert.True(copy.EnforceAxisLimits);
+        }
+
+        [Fact]
+        [Trait("Category", "RequiresRhino")]
+        public void Duplicate_PreservesEnforceAxisLimits_False()
+        {
+            Robot robot = CreateTestRobot();
+            RAPIDGenerator generator = new RAPIDGenerator(robot);
+            generator.EnforceAxisLimits = false;
+
+            RAPIDGenerator copy = generator.Duplicate();
+
+            Assert.False(copy.EnforceAxisLimits);
+        }
         #endregion
     }
 }

--- a/RobotComponents.Tests/Actions/RAPIDGeneratorTests.cs
+++ b/RobotComponents.Tests/Actions/RAPIDGeneratorTests.cs
@@ -280,5 +280,64 @@ namespace RobotComponents.Tests.Actions
             Assert.True(endProcLine < endModuleLine, "ENDPROC should come before ENDMODULE");
         }
         #endregion
+
+        #region Axis Limit Enforcement
+        [Fact]
+        [Trait("Category", "RequiresRhino")]
+        public void CreateModule_AxisViolation_EnforceTrue_ReturnsEmptyModule()
+        {
+            Robot robot = CreateTestRobot();
+            RAPIDGenerator generator = new RAPIDGenerator(robot);
+
+            // Axis 1 limit for IRB120 is [-165, 165]; 999 is well out of range
+            RobotJointPosition rjp = new RobotJointPosition(999, 0, 0, 0, 0, 0);
+            JointTarget target = new JointTarget("jt_bad", rjp);
+            Movement move = new Movement(MovementType.MoveAbsJ, target, new SpeedData(100), new ZoneData(10));
+
+            List<string> module = generator.CreateModule(new List<IAction> { move });
+
+            Assert.Empty(module);
+            Assert.NotEmpty(generator.ErrorText);
+        }
+
+        [Fact]
+        [Trait("Category", "RequiresRhino")]
+        public void CreateModule_AxisViolation_EnforceFalse_ReturnsFullModule()
+        {
+            Robot robot = CreateTestRobot();
+            RAPIDGenerator generator = new RAPIDGenerator(robot);
+            generator.EnforceAxisLimits = false;
+
+            RobotJointPosition rjp = new RobotJointPosition(999, 0, 0, 0, 0, 0);
+            JointTarget target = new JointTarget("jt_bad", rjp);
+            Movement move = new Movement(MovementType.MoveAbsJ, target, new SpeedData(100), new ZoneData(10));
+
+            List<string> module = generator.CreateModule(new List<IAction> { move });
+            string joined = string.Join(Environment.NewLine, module);
+
+            Assert.Contains("MODULE MainModule", joined);
+            Assert.Contains("ENDMODULE", joined);
+            Assert.NotEmpty(generator.ErrorText);
+        }
+
+        [Fact]
+        [Trait("Category", "RequiresRhino")]
+        public void CreateModule_NoViolation_EnforceTrue_ReturnsFullModule()
+        {
+            Robot robot = CreateTestRobot();
+            RAPIDGenerator generator = new RAPIDGenerator(robot);
+
+            RobotJointPosition rjp = new RobotJointPosition(0, 0, 0, 0, 0, 0);
+            JointTarget target = new JointTarget("jt_ok", rjp);
+            Movement move = new Movement(MovementType.MoveAbsJ, target, new SpeedData(100), new ZoneData(10));
+
+            List<string> module = generator.CreateModule(new List<IAction> { move });
+            string joined = string.Join(Environment.NewLine, module);
+
+            Assert.Contains("MODULE MainModule", joined);
+            Assert.Contains("ENDMODULE", joined);
+            Assert.Empty(generator.ErrorText);
+        }
+        #endregion
     }
 }


### PR DESCRIPTION
## Summary

- Axis limit violations now prevent RAPID code generation by default (hard error), closing a safety gap where out-of-range joint values could be deployed to a robot controller
- Adds an opt-in override (`EnforceAxisLimits = false`) to restore the previous warning-only behavior when intentional
- Fixes a coverage gap where RobotTargets converted to JointTargets via inverse kinematics were never validated against axis limits
- Violations are surfaced as red errors (not yellow warnings) in the Grasshopper component UI when enforcement is active
- Fixes pre-existing off-by-one in error message display limit (showed 31 instead of 30)

## Changes

### Core (`RobotComponents.ABB`)
- **Movement.cs**: Add `CheckAxisLimits` call after IK conversion of RobotTarget to JointTarget; use typed local to avoid unnecessary cast
- **RAPIDGenerator.cs**: Add `EnforceAxisLimits` property (default true), propagated through `Duplicate()`; `CreateModule` returns empty module when enforcement is on and errors exist; collect sub-generator errors before enforcement check

### UI (`RobotComponents.ABB.Gh`)
- **RAPIDGeneratorComponent.cs**: Add optional "Enforce Axis Limits" input parameter (index 10) with context menu toggle in its own separated section; switch `GH_RuntimeMessageLevel` from Warning to Error when enforcement is active; backward-compatible serialization using `ItemExists` guard; fix off-by-one in error display loop

### Tests (`RobotComponents.Tests`)
- **RAPIDGeneratorTests.cs**: Enforce-on + violation (empty module), enforce-off + violation (full module), no violation (full module), `Duplicate` preserves setting for both true and false
- **MovementTests.cs**: IK-converted RobotTarget produces axis limit errors; helper doc notes implicit enforcement default

## Test plan

- [x] Verify existing tests pass (valid joint targets still generate modules normally)
- [x] Verify new enforcement tests: violation + enforce=true → empty module, violation + enforce=false → full module with warnings
- [ ] Test in Grasshopper: connect a JointTarget with out-of-range axis values → component shows red error, no module output
- [ ] Test in Grasshopper: enable "Enforce Axis Limits" override via context menu → set to false → component shows yellow warning, module is generated
- [ ] Open an old .ghx file without the new setting → verify it loads without errors (backward compat)

Closes #38