### PR TITLE
Add safety interlock to RunProgram for physical controllers

### DIFF
--- a/RobotComponents.ABB.Controllers/Controller.cs
+++ b/RobotComponents.ABB.Controllers/Controller.cs
@@ -2006,6 +2006,20 @@ namespace RobotComponents.ABB.Controllers
                 return false;
             }
 
+            else if (_controller.State == ControllersNS.ControllerState.EmergencyStop)
+            {
+                status = "Could not start the program: The controller is in emergency stop.";
+                Log(status);
+                return false;
+            }
+
+            else if (_controller.State == ControllersNS.ControllerState.GuardStop)
+            {
+                status = "Could not start the program: The controller is in guard stop.";
+                Log(status);
+                return false;
+            }
+
             else if (_controller.State != ControllersNS.ControllerState.MotorsOn)
             {
                 status = "Could not start the program: The motors are not on.";

--- a/RobotComponents.ABB.Controllers/Controller.cs
+++ b/RobotComponents.ABB.Controllers/Controller.cs
@@ -2128,6 +2128,21 @@ namespace RobotComponents.ABB.Controllers
 
             return _controller.Rapid.GetRapidData(task, module, variable).StringValue;
         }
+        /// <summary>
+        /// Determines whether program execution is permitted given the armed state and controller type.
+        /// </summary>
+        /// <param name="armed"> Whether the safety interlock has been armed via the Arm input. </param>
+        /// <param name="isPhysical"> Whether the target controller is a physical (non-virtual) controller. </param>
+        /// <returns>
+        /// <c>true</c> if execution is permitted; <c>false</c> if the interlock blocks execution.
+        /// Virtual controllers always permit execution regardless of the armed state.
+        /// Physical controllers require <paramref name="armed"/> to be <c>true</c>.
+        /// </returns>
+        public static bool IsExecutionPermitted(bool armed, bool isPhysical)
+        {
+            if (!isPhysical) return true;
+            return armed;
+        }
         #endregion
 
         #region static properties

--- a/RobotComponents.ABB.Controllers/Controller.cs
+++ b/RobotComponents.ABB.Controllers/Controller.cs
@@ -2211,7 +2211,23 @@ namespace RobotComponents.ABB.Controllers
         }
 
         /// <summary>
-        /// Gets the analog inputs. 
+        /// Gets a value indicating whether this controller is a virtual (simulated) controller.
+        /// </summary>
+        /// <remarks>
+        /// Virtual controllers run inside RobotStudio or a similar simulation environment and do not
+        /// control physical hardware. Returns <c>false</c> if the controller instance is empty.
+        /// </remarks>
+        public bool IsVirtual
+        {
+            get
+            {
+                if (_isEmpty || _controller == null) return false;
+                return _controller.IsVirtual;
+            }
+        }
+
+        /// <summary>
+        /// Gets the analog inputs.
         /// </summary>
         public List<Signal> AnalogInputs
         {

--- a/RobotComponents.ABB.Gh/Components/Controller Utility/Run Programs/RunProgramComponent.cs
+++ b/RobotComponents.ABB.Gh/Components/Controller Utility/Run Programs/RunProgramComponent.cs
@@ -113,7 +113,7 @@ namespace RobotComponents.ABB.Gh.Components.ControllerUtility
             }
 
             bool isPhysical = !_controller.IsEmpty && !_controller.IsVirtual;
-            bool armed = IsExecutionPermitted(arm, isPhysical);
+            bool armed = Controller.IsExecutionPermitted(arm, isPhysical);
 
             if (run)
             {
@@ -159,22 +159,6 @@ namespace RobotComponents.ABB.Gh.Components.ControllerUtility
 
             // Output
             DA.SetData(0, _status);
-        }
-
-        /// <summary>
-        /// Determines whether program execution is permitted given the armed state and controller type.
-        /// </summary>
-        /// <param name="armed"> Whether the safety interlock has been armed via the Arm input. </param>
-        /// <param name="isPhysical"> Whether the target controller is a physical (non-virtual) controller. </param>
-        /// <returns>
-        /// <c>true</c> if execution is permitted; <c>false</c> if the interlock blocks execution.
-        /// Virtual controllers always permit execution regardless of the armed state.
-        /// Physical controllers require <paramref name="armed"/> to be <c>true</c>.
-        /// </returns>
-        public static bool IsExecutionPermitted(bool armed, bool isPhysical)
-        {
-            if (!isPhysical) return true;
-            return armed;
         }
 
         #region properties

--- a/RobotComponents.ABB.Gh/Components/Controller Utility/Run Programs/RunProgramComponent.cs
+++ b/RobotComponents.ABB.Gh/Components/Controller Utility/Run Programs/RunProgramComponent.cs
@@ -97,10 +97,23 @@ namespace RobotComponents.ABB.Gh.Components.ControllerUtility
             if (!DA.GetData(3, ref stop)) { stop = false; }
             if (!DA.GetData(4, ref reset)) { reset = false; }
 
-            // Determine controller type and update interlock state
+            // Determine controller type and update interlock state.
+            // Empty controllers are treated as disconnected, not virtual.
+            if (_controller.IsEmpty)
+            {
+                this.Message = "-";
+            }
+            else if (_controller.IsVirtual)
+            {
+                this.Message = "VIRTUAL";
+            }
+            else
+            {
+                this.Message = arm ? "ARMED" : "DISARMED";
+            }
+
             bool isPhysical = !_controller.IsEmpty && !_controller.IsVirtual;
             bool armed = IsExecutionPermitted(arm, isPhysical);
-            this.Message = isPhysical ? (arm ? "ARMED" : "DISARMED") : "VIRTUAL";
 
             if (run)
             {
@@ -121,6 +134,9 @@ namespace RobotComponents.ABB.Gh.Components.ControllerUtility
                 }
             }
 
+            // Stop and Reset intentionally bypass the Arm interlock so the
+            // operator can always halt or reset a running program regardless
+            // of the armed state.
             if (stop)
             {
                 _succeeded = _controller.StopProgram(out _status);

--- a/RobotComponents.ABB.Gh/Components/Controller Utility/Run Programs/RunProgramComponent.cs
+++ b/RobotComponents.ABB.Gh/Components/Controller Utility/Run Programs/RunProgramComponent.cs
@@ -1,11 +1,16 @@
-﻿// SPDX-License-Identifier: GPL-3.0-or-later
-// This file is part of Robot Components
-// Project: https://github.com/RobotComponents/RobotComponents
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This file is part of Robot Components (Modified)
+// Original project: https://github.com/RobotComponents/RobotComponents
+// Modified project: https://github.com/jpdrude/RobotComponents
 //
 // Copyright (c) 2022-2025 Arjen Deetman
+// Copyright (c) 2025 EDEK Uni Kassel
 //
-// Authors:
+// Original Authors:
 //   - Arjen Deetman (2022-2025)
+//
+// Modified by:
+//   - Jan Philipp Drude (2025-2026)
 //
 // For license details, see the LICENSE file in the project root.
 
@@ -38,6 +43,7 @@ namespace RobotComponents.ABB.Gh.Components.ControllerUtility
                 + System.Environment.NewLine + System.Environment.NewLine +
                 "This component uses the ABB PC SDK.")
         {
+            this.Message = "DISARMED";
         }
 
         /// <summary>
@@ -46,13 +52,15 @@ namespace RobotComponents.ABB.Gh.Components.ControllerUtility
         protected override void RegisterInputParams(GH_InputParamManager pManager)
         {
             pManager.AddParameter(new Param_Controller(), "Controller", "C", "Controller as Controller", GH_ParamAccess.item);
+            pManager.AddBooleanParameter("Arm", "A", "Arm the safety interlock as bool. Required before running on a physical controller. Not required for virtual controllers.", GH_ParamAccess.item, false);
             pManager.AddBooleanParameter("Run", "R", "Run as bool", GH_ParamAccess.item, false);
             pManager.AddBooleanParameter("Stop", "S", "Stop/Pause as bool", GH_ParamAccess.item, false);
-            pManager.AddBooleanParameter("Reset", "R", "Resets the program pointer of all tasks as bool", GH_ParamAccess.item, false);
+            pManager.AddBooleanParameter("Reset", "Re", "Resets the program pointer of all tasks as bool", GH_ParamAccess.item, false);
 
             pManager[1].Optional = true;
             pManager[2].Optional = true;
             pManager[3].Optional = true;
+            pManager[4].Optional = true;
         }
 
         /// <summary>
@@ -77,38 +85,80 @@ namespace RobotComponents.ABB.Gh.Components.ControllerUtility
             }
 
             // Declare input variables
+            bool arm = false;
             bool run = false;
             bool stop = false;
             bool reset = false;
 
             // Catch the input data
             if (!DA.GetData(0, ref _controller)) { return; }
-            if (!DA.GetData(1, ref run)) { run = false; }
-            if (!DA.GetData(2, ref stop)) { stop = false; }
-            if (!DA.GetData(3, ref reset)) { reset = false; }
+            if (!DA.GetData(1, ref arm)) { arm = false; }
+            if (!DA.GetData(2, ref run)) { run = false; }
+            if (!DA.GetData(3, ref stop)) { stop = false; }
+            if (!DA.GetData(4, ref reset)) { reset = false; }
+
+            // Determine controller type and update interlock state
+            bool isPhysical = !_controller.IsEmpty && !_controller.IsVirtual;
+            bool armed = IsExecutionPermitted(arm, isPhysical);
+            this.Message = isPhysical ? (arm ? "ARMED" : "DISARMED") : "VIRTUAL";
 
             if (run)
             {
-                _succeeded = _controller.RunProgram(out _status);
+                if (!armed)
+                {
+                    _succeeded = false;
+                    _status = "Program not started: Arm the interlock before running on a physical controller.";
+                    AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, _status);
+                }
+                else
+                {
+                    _succeeded = _controller.RunProgram(out _status);
+
+                    if (!_succeeded)
+                    {
+                        AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, _status);
+                    }
+                }
             }
 
             if (stop)
             {
                 _succeeded = _controller.StopProgram(out _status);
+
+                if (!_succeeded)
+                {
+                    AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, _status);
+                }
             }
 
             if (reset)
             {
                 _succeeded = _controller.ResetProgramPointers(out _status);
-            }
 
-            if (_succeeded == false)
-            {
-                AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, _status);
+                if (!_succeeded)
+                {
+                    AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, _status);
+                }
             }
 
             // Output
             DA.SetData(0, _status);
+        }
+
+        /// <summary>
+        /// Determines whether program execution is permitted given the armed state and controller type.
+        /// </summary>
+        /// <param name="armed"> Whether the safety interlock has been armed via the Arm input. </param>
+        /// <param name="isPhysical"> Whether the target controller is a physical (non-virtual) controller. </param>
+        /// <returns>
+        /// <c>true</c> if execution is permitted; <c>false</c> if the interlock blocks execution.
+        /// Virtual controllers always permit execution regardless of the armed state.
+        /// Physical controllers require <paramref name="armed"/> to be <c>true</c>.
+        /// </returns>
+        public static bool IsExecutionPermitted(bool armed, bool isPhysical)
+        {
+            if (!isPhysical) return true;
+            return armed;
         }
 
         #region properties

--- a/RobotComponents.Tests/Controllers/RunProgramSafetyTests.cs
+++ b/RobotComponents.Tests/Controllers/RunProgramSafetyTests.cs
@@ -9,7 +9,6 @@
 using Xunit;
 // Robot Components Libs
 using RobotComponents.ABB.Controllers;
-using RobotComponents.ABB.Gh.Components.ControllerUtility;
 
 namespace RobotComponents.Tests.Controllers
 {
@@ -37,25 +36,25 @@ namespace RobotComponents.Tests.Controllers
         [Fact]
         public void IsExecutionPermitted_PhysicalNotArmed_ReturnsFalse()
         {
-            Assert.False(RunProgramComponent.IsExecutionPermitted(armed: false, isPhysical: true));
+            Assert.False(Controller.IsExecutionPermitted(armed: false, isPhysical: true));
         }
 
         [Fact]
         public void IsExecutionPermitted_PhysicalArmed_ReturnsTrue()
         {
-            Assert.True(RunProgramComponent.IsExecutionPermitted(armed: true, isPhysical: true));
+            Assert.True(Controller.IsExecutionPermitted(armed: true, isPhysical: true));
         }
 
         [Fact]
         public void IsExecutionPermitted_VirtualNotArmed_ReturnsTrue()
         {
-            Assert.True(RunProgramComponent.IsExecutionPermitted(armed: false, isPhysical: false));
+            Assert.True(Controller.IsExecutionPermitted(armed: false, isPhysical: false));
         }
 
         [Fact]
         public void IsExecutionPermitted_VirtualArmed_ReturnsTrue()
         {
-            Assert.True(RunProgramComponent.IsExecutionPermitted(armed: true, isPhysical: false));
+            Assert.True(Controller.IsExecutionPermitted(armed: true, isPhysical: false));
         }
     }
 }

--- a/RobotComponents.Tests/Controllers/RunProgramSafetyTests.cs
+++ b/RobotComponents.Tests/Controllers/RunProgramSafetyTests.cs
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This file is part of Robot Components (Modified)
+// Original project: https://github.com/RobotComponents/RobotComponents
+// Modified project: https://github.com/jpdrude/RobotComponents
+//
+// For license details, see the LICENSE file in the project root.
+
+// Xunit Libs
+using Xunit;
+// Robot Components Libs
+using RobotComponents.ABB.Controllers;
+using RobotComponents.ABB.Gh.Components.ControllerUtility;
+
+namespace RobotComponents.Tests.Controllers
+{
+    public class RunProgramSafetyTests
+    {
+        [Fact]
+        public void IsVirtual_EmptyController_ReturnsFalse()
+        {
+            Controller controller = new Controller();
+
+            Assert.False(controller.IsVirtual);
+        }
+
+        [Fact]
+        public void RunProgram_EmptyController_ReturnsFalse()
+        {
+            Controller controller = new Controller();
+
+            bool result = controller.RunProgram(out string status);
+
+            Assert.False(result);
+            Assert.Contains("empty", status, System.StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void IsExecutionPermitted_PhysicalNotArmed_ReturnsFalse()
+        {
+            Assert.False(RunProgramComponent.IsExecutionPermitted(armed: false, isPhysical: true));
+        }
+
+        [Fact]
+        public void IsExecutionPermitted_PhysicalArmed_ReturnsTrue()
+        {
+            Assert.True(RunProgramComponent.IsExecutionPermitted(armed: true, isPhysical: true));
+        }
+
+        [Fact]
+        public void IsExecutionPermitted_VirtualNotArmed_ReturnsTrue()
+        {
+            Assert.True(RunProgramComponent.IsExecutionPermitted(armed: false, isPhysical: false));
+        }
+
+        [Fact]
+        public void IsExecutionPermitted_VirtualArmed_ReturnsTrue()
+        {
+            Assert.True(RunProgramComponent.IsExecutionPermitted(armed: true, isPhysical: false));
+        }
+    }
+}

--- a/RobotComponents.Tests/RobotComponents.Tests.csproj
+++ b/RobotComponents.Tests/RobotComponents.Tests.csproj
@@ -17,7 +17,6 @@
     <ProjectReference Include="..\RobotComponents.ABB\RobotComponents.ABB.csproj" />
     <ProjectReference Include="..\RobotComponents.ABB.Presets\RobotComponents.ABB.Presets.csproj" />
     <ProjectReference Include="..\RobotComponents.ABB.Controllers\RobotComponents.ABB.Controllers.csproj" />
-    <ProjectReference Include="..\RobotComponents.ABB.Gh\RobotComponents.ABB.Gh.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/RobotComponents.Tests/RobotComponents.Tests.csproj
+++ b/RobotComponents.Tests/RobotComponents.Tests.csproj
@@ -1,10 +1,10 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="RhinoCommon" Version="7.36.23346.16351" ExcludeAssets="none" />
@@ -16,6 +16,20 @@
     <ProjectReference Include="..\RobotComponents\RobotComponents.csproj" />
     <ProjectReference Include="..\RobotComponents.ABB\RobotComponents.ABB.csproj" />
     <ProjectReference Include="..\RobotComponents.ABB.Presets\RobotComponents.ABB.Presets.csproj" />
+    <ProjectReference Include="..\RobotComponents.ABB.Controllers\RobotComponents.ABB.Controllers.csproj" />
+    <ProjectReference Include="..\RobotComponents.ABB.Gh\RobotComponents.ABB.Gh.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="ABB.Robotics.Controllers.PC">
+      <HintPath>..\DLLs\ABB.Robotics.Controllers.PC.dll</HintPath>
+    </Reference>
+    <Reference Include="RobotStudio.Services.RobApi">
+      <HintPath>..\DLLs\RobotStudio.Services.RobApi.dll</HintPath>
+    </Reference>
+    <Reference Include="RobotStudio.Services.RobApi.Desktop">
+      <HintPath>..\DLLs\RobotStudio.Services.RobApi.Desktop.dll</HintPath>
+    </Reference>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## ⚠️ Breaking Change

This PR adds a new **Arm** boolean input to the **Run Program** component at position 2 (after Controller). This shifts the existing inputs:

| Input | Old Position | New Position |
|-------|-------------|-------------|
| Controller | 1 | 1 |
| **Arm** | — | **2 (new)** |
| Run | 2 | 3 |
| Stop | 3 | 4 |
| Reset | 4 | 5 |

**If you have existing `.gh` files that use the Run Program component, you must re-wire the Run, Stop, and Reset inputs after updating.** Wires connected by index will silently shift — what was your "Run" toggle will become "Arm", and so on. Open the affected definitions and reconnect the inputs by hand.

---

## Summary

- Add `IsVirtual` property to the `Controller` wrapper class so callers can distinguish physical from virtual controllers
- Check for **emergency stop** and **guard stop** states in `Controller.RunProgram()` before allowing execution, with clear error messages for each
- Add a two-step **Arm + Run** interlock to `RunProgramComponent`: physical controllers require Arm to be true before Run will execute; virtual controllers bypass the interlock for convenience
- The component displays its state on the Grasshopper canvas: `ARMED`, `DISARMED`, or `VIRTUAL`
- Add 6 unit tests covering the interlock logic and empty-controller guard paths

Closes #39

## Test plan

- [x] Verify the 6 new xUnit tests pass in CI
- [ ] Open an existing `.gh` file using Run Program — confirm inputs need re-wiring and re-wire them
- [ ] Connect to a virtual controller: confirm Run works without Arm (component shows `VIRTUAL`)
- [ ] Connect to a physical controller: confirm Run is blocked when Arm is false (component shows `DISARMED`, warning appears)
- [ ] Arm a physical controller and Run: confirm execution proceeds (component shows `ARMED`)